### PR TITLE
Feature/8 status environment badges

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -3,7 +3,14 @@ import type {Decorator} from '@storybook/react-vite';
 import AdminSettingsProvider from '@/context/AdminSettingsProvider';
 
 export const withAdminSettingsProvider: Decorator = (Story, {parameters}) => (
-  <AdminSettingsProvider environment={parameters?.adminSettings?.environment ?? 'storybook-test'}>
+  <AdminSettingsProvider
+    environmentInfo={{
+      label: parameters?.adminSettings?.environmentInfo?.label ?? 'storybook-test',
+      showBadge: parameters?.adminSettings?.environmentInfo?.showBadge ?? true,
+      backgroundColor: parameters?.adminSettings?.environmentInfo?.backgroundColor,
+      foregroundColor: parameters?.adminSettings?.environmentInfo?.foregroundColor,
+    }}
+  >
     <Story />
   </AdminSettingsProvider>
 );

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,0 +1,9 @@
+import type {Decorator} from '@storybook/react-vite';
+
+import AdminSettingsProvider from '@/context/AdminSettingsProvider';
+
+export const withAdminSettingsProvider: Decorator = (Story, {parameters}) => (
+  <AdminSettingsProvider environment={parameters?.adminSettings?.environment ?? 'storybook-test'}>
+    <Story />
+  </AdminSettingsProvider>
+);

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,9 +3,12 @@ import '@maykin-ui/admin-ui/style';
 import '@maykin-ui/admin-ui/style/themes/purple-rain.css';
 import type {Preview} from '@storybook/react-vite';
 
+import {withAdminSettingsProvider} from '@/sb-decorators';
+
 import {reactIntl} from './reactIntl';
 
 const preview: Preview = {
+  decorators: [withAdminSettingsProvider],
   parameters: {
     reactIntl,
     controls: {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,3 +1,6 @@
+import '@maykin-ui/admin-ui/style';
+// @TODO update theme after upgrading admin-ui
+import '@maykin-ui/admin-ui/style/themes/purple-rain.css';
 import type {Preview} from '@storybook/react-vite';
 
 import {reactIntl} from './reactIntl';

--- a/i18n/compiled/en.json
+++ b/i18n/compiled/en.json
@@ -5,6 +5,12 @@
       "value": "Categories"
     }
   ],
+  "BfpzoP": [
+    {
+      "type": 0,
+      "value": "Scheduled form"
+    }
+  ],
   "DPiQcJ": [
     {
       "type": 0,
@@ -35,10 +41,28 @@
       "value": "Design"
     }
   ],
+  "e/VFua": [
+    {
+      "type": 0,
+      "value": "Active form"
+    }
+  ],
+  "pJ2Kxl": [
+    {
+      "type": 0,
+      "value": "Form in maintenance mode"
+    }
+  ],
   "pSTlTi": [
     {
       "type": 0,
       "value": "Settings"
+    }
+  ],
+  "t5YtWB": [
+    {
+      "type": 0,
+      "value": "Inactive form"
     }
   ]
 }

--- a/i18n/compiled/nl.json
+++ b/i18n/compiled/nl.json
@@ -5,6 +5,12 @@
       "value": "Categorieën"
     }
   ],
+  "BfpzoP": [
+    {
+      "type": 0,
+      "value": "Formulier ingepland"
+    }
+  ],
   "DPiQcJ": [
     {
       "type": 0,
@@ -35,10 +41,28 @@
       "value": "Ontwerpen"
     }
   ],
+  "e/VFua": [
+    {
+      "type": 0,
+      "value": "Formulier actief"
+    }
+  ],
+  "pJ2Kxl": [
+    {
+      "type": 0,
+      "value": "Formulier in onderhoudsmodus"
+    }
+  ],
   "pSTlTi": [
     {
       "type": 0,
       "value": "Instellingen"
+    }
+  ],
+  "t5YtWB": [
+    {
+      "type": 0,
+      "value": "Formulier niet actief"
     }
   ]
 }

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -4,6 +4,11 @@
     "description": "Route breadcrumb label for form categories",
     "originalDefault": "categories"
   },
+  "BfpzoP": {
+    "defaultMessage": "Scheduled form",
+    "description": "Label for form status \"scheduled\"",
+    "originalDefault": "Scheduled form"
+  },
   "DPiQcJ": {
     "defaultMessage": "Form submission statistics",
     "description": "Route breadcrumb label for form submission statistics",
@@ -29,9 +34,24 @@
     "description": "Route breadcrumb label for form detail design",
     "originalDefault": "design"
   },
+  "e/VFua": {
+    "defaultMessage": "Active form",
+    "description": "Label for form status \"active\"",
+    "originalDefault": "Active form"
+  },
+  "pJ2Kxl": {
+    "defaultMessage": "Form in maintenance mode",
+    "description": "Label for form status \"maintenance\"",
+    "originalDefault": "Form in maintenance mode"
+  },
   "pSTlTi": {
     "defaultMessage": "Settings",
     "description": "Route breadcrumb label for form detail settings",
     "originalDefault": "settings"
+  },
+  "t5YtWB": {
+    "defaultMessage": "Inactive form",
+    "description": "Label for form status \"inactive\"",
+    "originalDefault": "Inactive form"
   }
 }

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -4,6 +4,11 @@
     "description": "Route breadcrumb label for form categories",
     "originalDefault": "categories"
   },
+  "BfpzoP": {
+    "defaultMessage": "Formulier ingepland",
+    "description": "Label for form status \"scheduled\"",
+    "originalDefault": "Scheduled form"
+  },
   "DPiQcJ": {
     "defaultMessage": "Inzendingstatistieken",
     "description": "Route breadcrumb label for form submission statistics",
@@ -29,9 +34,24 @@
     "description": "Route breadcrumb label for form detail design",
     "originalDefault": "design"
   },
+  "e/VFua": {
+    "defaultMessage": "Formulier actief",
+    "description": "Label for form status \"active\"",
+    "originalDefault": "Active form"
+  },
+  "pJ2Kxl": {
+    "defaultMessage": "Formulier in onderhoudsmodus",
+    "description": "Label for form status \"maintenance\"",
+    "originalDefault": "Form in maintenance mode"
+  },
   "pSTlTi": {
     "defaultMessage": "Instellingen",
     "description": "Route breadcrumb label for form detail settings",
     "originalDefault": "settings"
+  },
+  "t5YtWB": {
+    "defaultMessage": "Formulier niet actief",
+    "description": "Label for form status \"inactive\"",
+    "originalDefault": "Inactive form"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intl": "^7.0.0",
+        "sass-embedded": "^1.97.3",
         "storybook": "^10.1.11",
         "storybook-addon-remix-react-router": "^6.0.0",
         "storybook-react-intl": "^10.0.1",
@@ -386,6 +387,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -1938,6 +1946,316 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
@@ -4711,6 +5029,23 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -4815,6 +5150,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
+      "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5093,6 +5435,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -6545,6 +6898,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
+      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7788,6 +8148,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -8840,6 +9208,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -9042,6 +9425,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -9095,6 +9488,392 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/sass-embedded": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.97.3.tgz",
+      "integrity": "sha512-eKzFy13Nk+IRHhlAwP3sfuv+PzOrvzUkwJK2hdoCKYcWGSdmwFpeGpWmyewdw8EgBnsKaSBtgf/0b2K635ecSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.5.0",
+        "colorjs.io": "^0.5.0",
+        "immutable": "^5.0.2",
+        "rxjs": "^7.4.0",
+        "supports-color": "^8.1.1",
+        "sync-child-process": "^1.0.2",
+        "varint": "^6.0.0"
+      },
+      "bin": {
+        "sass": "dist/bin/sass.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "sass-embedded-all-unknown": "1.97.3",
+        "sass-embedded-android-arm": "1.97.3",
+        "sass-embedded-android-arm64": "1.97.3",
+        "sass-embedded-android-riscv64": "1.97.3",
+        "sass-embedded-android-x64": "1.97.3",
+        "sass-embedded-darwin-arm64": "1.97.3",
+        "sass-embedded-darwin-x64": "1.97.3",
+        "sass-embedded-linux-arm": "1.97.3",
+        "sass-embedded-linux-arm64": "1.97.3",
+        "sass-embedded-linux-musl-arm": "1.97.3",
+        "sass-embedded-linux-musl-arm64": "1.97.3",
+        "sass-embedded-linux-musl-riscv64": "1.97.3",
+        "sass-embedded-linux-musl-x64": "1.97.3",
+        "sass-embedded-linux-riscv64": "1.97.3",
+        "sass-embedded-linux-x64": "1.97.3",
+        "sass-embedded-unknown-all": "1.97.3",
+        "sass-embedded-win32-arm64": "1.97.3",
+        "sass-embedded-win32-x64": "1.97.3"
+      }
+    },
+    "node_modules/sass-embedded-all-unknown": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.97.3.tgz",
+      "integrity": "sha512-t6N46NlPuXiY3rlmG6/+1nwebOBOaLFOOVqNQOC2cJhghOD4hh2kHNQQTorCsbY9S1Kir2la1/XLBwOJfui0xg==",
+      "cpu": [
+        "!arm",
+        "!arm64",
+        "!riscv64",
+        "!x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "sass": "1.97.3"
+      }
+    },
+    "node_modules/sass-embedded-android-arm": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.97.3.tgz",
+      "integrity": "sha512-cRTtf/KV/q0nzGZoUzVkeIVVFv3L/tS1w4WnlHapphsjTXF/duTxI8JOU1c/9GhRPiMdfeXH7vYNcMmtjwX7jg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.97.3.tgz",
+      "integrity": "sha512-aiZ6iqiHsUsaDx0EFbbmmA0QgxicSxVVN3lnJJ0f1RStY0DthUkquGT5RJ4TPdaZ6ebeJWkboV4bra+CP766eA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-riscv64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.97.3.tgz",
+      "integrity": "sha512-zVEDgl9JJodofGHobaM/q6pNETG69uuBIGQHRo789jloESxxZe82lI3AWJQuPmYCOG5ElfRthqgv89h3gTeLYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-x64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.97.3.tgz",
+      "integrity": "sha512-3ke0le7ZKepyXn/dKKspYkpBC0zUk/BMciyP5ajQUDy4qJwobd8zXdAq6kOkdiMB+d9UFJOmEkvgFJHl3lqwcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-arm64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.97.3.tgz",
+      "integrity": "sha512-fuqMTqO4gbOmA/kC5b9y9xxNYw6zDEyfOtMgabS7Mz93wimSk2M1quQaTJnL98Mkcsl2j+7shNHxIS/qpcIDDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-x64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.97.3.tgz",
+      "integrity": "sha512-b/2RBs/2bZpP8lMkyZ0Px0vkVkT8uBd0YXpOwK7iOwYkAT8SsO4+WdVwErsqC65vI5e1e5p1bb20tuwsoQBMVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.97.3.tgz",
+      "integrity": "sha512-2lPQ7HQQg4CKsH18FTsj2hbw5GJa6sBQgDsls+cV7buXlHjqF8iTKhAQViT6nrpLK/e8nFCoaRgSqEC8xMnXuA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.97.3.tgz",
+      "integrity": "sha512-IP1+2otCT3DuV46ooxPaOKV1oL5rLjteRzf8ldZtfIEcwhSgSsHgA71CbjYgLEwMY9h4jeal8Jfv3QnedPvSjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.97.3.tgz",
+      "integrity": "sha512-cBTMU68X2opBpoYsSZnI321gnoaiMBEtc+60CKCclN6PCL3W3uXm8g4TLoil1hDD6mqU9YYNlVG6sJ+ZNef6Lg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.97.3.tgz",
+      "integrity": "sha512-Lij0SdZCsr+mNRSyDZ7XtJpXEITrYsaGbOTz5e6uFLJ9bmzUbV7M8BXz2/cA7bhfpRPT7/lwRKPdV4+aR9Ozcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-riscv64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.97.3.tgz",
+      "integrity": "sha512-sBeLFIzMGshR4WmHAD4oIM7WJVkSoCIEwutzptFtGlSlwfNiijULp+J5hA2KteGvI6Gji35apR5aWj66wEn/iA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-x64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.97.3.tgz",
+      "integrity": "sha512-/oWJ+OVrDg7ADDQxRLC/4g1+Nsz1g4mkYS2t6XmyMJKFTFK50FVI2t5sOdFH+zmMp+nXHKM036W94y9m4jjEcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-riscv64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.97.3.tgz",
+      "integrity": "sha512-l3IfySApLVYdNx0Kjm7Zehte1CDPZVcldma3dZt+TfzvlAEerM6YDgsk5XEj3L8eHBCgHgF4A0MJspHEo2WNfA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-x64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.97.3.tgz",
+      "integrity": "sha512-Kwqwc/jSSlcpRjULAOVbndqEy2GBzo6OBmmuBVINWUaJLJ8Kczz3vIsDUWLfWz/kTEw9FHBSiL0WCtYLVAXSLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-unknown-all": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.97.3.tgz",
+      "integrity": "sha512-/GHajyYJmvb0IABUQHbVHf1nuHPtIDo/ClMZ81IDr59wT5CNcMe7/dMNujXwWugtQVGI5UGmqXWZQCeoGnct8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!android",
+        "!darwin",
+        "!linux",
+        "!win32"
+      ],
+      "dependencies": {
+        "sass": "1.97.3"
+      }
+    },
+    "node_modules/sass-embedded-win32-arm64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.97.3.tgz",
+      "integrity": "sha512-RDGtRS1GVvQfMGAmVXNxYiUOvPzn9oO1zYB/XUM9fudDRnieYTcUytpNTQZLs6Y1KfJxgt5Y+giRceC92fT8Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-x64": {
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.97.3.tgz",
+      "integrity": "sha512-SFRa2lED9UEwV6vIGeBXeBOLKF+rowF3WmNfb/BzhxmdAsKofCXrJ8ePW7OcDVrvNEbTOGwhsReIsF5sH8fVaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/scheduler": {
@@ -9940,6 +10719,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sync-child-process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
+      "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sync-message-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/sync-message-port": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz",
+      "integrity": "sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -10468,6 +11270,13 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^7.0.0",
+    "sass-embedded": "^1.97.3",
     "storybook": "^10.1.11",
     "storybook-addon-remix-react-router": "^6.0.0",
     "storybook-react-intl": "^10.0.1",

--- a/src/AdminUI.tsx
+++ b/src/AdminUI.tsx
@@ -1,3 +1,6 @@
+import '@maykin-ui/admin-ui/style';
+// @TODO update theme after upgrading admin-ui
+import '@maykin-ui/admin-ui/style/themes/purple-rain.css';
 import React from 'react';
 import {RouterProvider, createBrowserRouter} from 'react-router';
 

--- a/src/AdminUI.tsx
+++ b/src/AdminUI.tsx
@@ -1,19 +1,29 @@
 import React from 'react';
 import {RouterProvider, createBrowserRouter} from 'react-router';
 
+import AdminSettingsProvider from '@/context/AdminSettingsProvider';
 import routes from '@/routes';
+
+interface AdminUIProps {
+  /**
+   * The environment name of the Open Forms instance.
+   */
+  environment: string;
+}
 
 /**
  * Main component to render the Open Forms Admin UI.
  */
-const AdminUI: React.FC = () => {
+const AdminUI: React.FC<AdminUIProps> = ({environment}) => {
   const router = createBrowserRouter(routes, {
     basename: '/admin-ui',
   });
 
   return (
     <React.StrictMode>
-      <RouterProvider router={router} />
+      <AdminSettingsProvider environment={environment}>
+        <RouterProvider router={router} />
+      </AdminSettingsProvider>
     </React.StrictMode>
   );
 };

--- a/src/AdminUI.tsx
+++ b/src/AdminUI.tsx
@@ -5,26 +5,27 @@ import React from 'react';
 import {RouterProvider, createBrowserRouter} from 'react-router';
 
 import AdminSettingsProvider from '@/context/AdminSettingsProvider';
+import type {AdminSettings} from '@/context/context';
 import routes from '@/routes';
 
 interface AdminUIProps {
   /**
-   * The environment name of the Open Forms instance.
+   * Configuration for the Open Forms environment.
    */
-  environment: string;
+  environmentInfo: AdminSettings['environmentInfo'];
 }
 
 /**
  * Main component to render the Open Forms Admin UI.
  */
-const AdminUI: React.FC<AdminUIProps> = ({environment}) => {
+const AdminUI: React.FC<AdminUIProps> = ({environmentInfo}) => {
   const router = createBrowserRouter(routes, {
     basename: '/admin-ui',
   });
 
   return (
     <React.StrictMode>
-      <AdminSettingsProvider environment={environment}>
+      <AdminSettingsProvider environmentInfo={environmentInfo}>
         <RouterProvider router={router} />
       </AdminSettingsProvider>
     </React.StrictMode>

--- a/src/components/badge/EnvironmentBadge.scss
+++ b/src/components/badge/EnvironmentBadge.scss
@@ -1,4 +1,0 @@
-.openforms-environment-badge {
-  --mykn-badge-color-background: #e8a600;
-  --mykn-badge-color-text: var(--theme-base-foreground);
-}

--- a/src/components/badge/EnvironmentBadge.scss
+++ b/src/components/badge/EnvironmentBadge.scss
@@ -1,0 +1,4 @@
+.openforms-environment-badge {
+  --mykn-badge-color-background: #e8a600;
+  --mykn-badge-color-text: var(--theme-base-foreground);
+}

--- a/src/components/badge/EnvironmentBadge.stories.tsx
+++ b/src/components/badge/EnvironmentBadge.stories.tsx
@@ -1,0 +1,14 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+
+import EnvironmentBadge from '@/components/badge/EnvironmentBadge';
+import {withAdminSettingsProvider} from '@/sb-decorators';
+
+export default {
+  title: 'Internal API / Badge / Environment Badge',
+  component: EnvironmentBadge,
+  decorators: [withAdminSettingsProvider],
+} satisfies Meta<typeof EnvironmentBadge>;
+
+type Story = StoryObj<typeof EnvironmentBadge>;
+
+export const Default: Story = {};

--- a/src/components/badge/EnvironmentBadge.stories.tsx
+++ b/src/components/badge/EnvironmentBadge.stories.tsx
@@ -10,3 +10,24 @@ export default {
 type Story = StoryObj<typeof EnvironmentBadge>;
 
 export const Default: Story = {};
+
+export const WithCustomBackgroundAndForeground: Story = {
+  parameters: {
+    adminSettings: {
+      environmentInfo: {
+        backgroundColor: 'limegreen',
+        foregroundColor: 'white',
+      },
+    },
+  },
+};
+
+export const HideEnvironmentBadge: Story = {
+  parameters: {
+    adminSettings: {
+      environmentInfo: {
+        showEnvironmentInfo: false,
+      },
+    },
+  },
+};

--- a/src/components/badge/EnvironmentBadge.stories.tsx
+++ b/src/components/badge/EnvironmentBadge.stories.tsx
@@ -1,12 +1,10 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
 
 import EnvironmentBadge from '@/components/badge/EnvironmentBadge';
-import {withAdminSettingsProvider} from '@/sb-decorators';
 
 export default {
   title: 'Internal API / Badge / Environment Badge',
   component: EnvironmentBadge,
-  decorators: [withAdminSettingsProvider],
 } satisfies Meta<typeof EnvironmentBadge>;
 
 type Story = StoryObj<typeof EnvironmentBadge>;

--- a/src/components/badge/EnvironmentBadge.tsx
+++ b/src/components/badge/EnvironmentBadge.tsx
@@ -1,0 +1,13 @@
+import {Badge} from '@maykin-ui/admin-ui';
+
+import {useAdminSettings} from '@/hooks/useAdminSettings';
+
+import './EnvironmentBadge.scss';
+
+const EnvironmentBadge = () => {
+  const {environment} = useAdminSettings();
+
+  return <Badge className="mykn-badge openforms-environment-badge">{environment}</Badge>;
+};
+
+export default EnvironmentBadge;

--- a/src/components/badge/EnvironmentBadge.tsx
+++ b/src/components/badge/EnvironmentBadge.tsx
@@ -2,12 +2,22 @@ import {Badge} from '@maykin-ui/admin-ui';
 
 import {useAdminSettings} from '@/hooks/useAdminSettings';
 
-import './EnvironmentBadge.scss';
-
 const EnvironmentBadge = () => {
-  const {environment} = useAdminSettings();
+  const {environmentInfo} = useAdminSettings();
+  const {label, showBadge, backgroundColor, foregroundColor} = environmentInfo;
 
-  return <Badge className="mykn-badge openforms-environment-badge">{environment}</Badge>;
+  if (!showBadge) return null;
+
+  return (
+    <Badge
+      style={{
+        '--mykn-badge-color-background': backgroundColor ?? '#e8a600',
+        '--mykn-badge-color-text': foregroundColor ?? '#333333',
+      }}
+    >
+      {label}
+    </Badge>
+  );
 };
 
 export default EnvironmentBadge;

--- a/src/components/badge/FormStatusBadge.stories.tsx
+++ b/src/components/badge/FormStatusBadge.stories.tsx
@@ -1,0 +1,36 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+
+import {withAdminSettingsProvider} from '@/sb-decorators';
+
+import FormStatusBadge from './FormStatusBadge';
+
+export default {
+  title: 'Internal API / Badge / Form Status Badge',
+  component: FormStatusBadge,
+  decorators: [withAdminSettingsProvider],
+  args: {
+    status: 'active',
+  },
+} satisfies Meta<typeof FormStatusBadge>;
+
+type Story = StoryObj<typeof FormStatusBadge>;
+
+export const Default: Story = {};
+
+export const InInactiveMode: Story = {
+  args: {
+    status: 'inactive',
+  },
+};
+
+export const InMaintenanceMode: Story = {
+  args: {
+    status: 'maintenance',
+  },
+};
+
+export const InScheduledMode: Story = {
+  args: {
+    status: 'scheduled',
+  },
+};

--- a/src/components/badge/FormStatusBadge.stories.tsx
+++ b/src/components/badge/FormStatusBadge.stories.tsx
@@ -1,13 +1,10 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
 
-import {withAdminSettingsProvider} from '@/sb-decorators';
-
 import FormStatusBadge from './FormStatusBadge';
 
 export default {
   title: 'Internal API / Badge / Form Status Badge',
   component: FormStatusBadge,
-  decorators: [withAdminSettingsProvider],
   args: {
     status: 'active',
   },

--- a/src/components/badge/FormStatusBadge.tsx
+++ b/src/components/badge/FormStatusBadge.tsx
@@ -1,0 +1,46 @@
+import type {BadgeProps} from '@maykin-ui/admin-ui';
+import {Badge} from '@maykin-ui/admin-ui';
+import {FormattedMessage, defineMessages} from 'react-intl';
+
+type FormStatus = 'active' | 'inactive' | 'maintenance' | 'scheduled';
+
+export interface FormStatusBadgeProps {
+  status: FormStatus;
+}
+
+const STATUS_LABELS = defineMessages<FormStatus>({
+  active: {
+    description: 'Label for form status "active"',
+    defaultMessage: 'Active form',
+  },
+  inactive: {
+    description: 'Label for form status "inactive"',
+    defaultMessage: 'Inactive form',
+  },
+  maintenance: {
+    description: 'Label for form status "maintenance"',
+    defaultMessage: 'Form in maintenance mode',
+  },
+  scheduled: {
+    description: 'Label for form status "scheduled"',
+    defaultMessage: 'Scheduled form',
+  },
+});
+
+const STATUS_BADGE_VARIANTS: Record<FormStatus, BadgeProps['variant']> = {
+  active: 'success',
+  inactive: 'danger',
+  maintenance: 'danger',
+  scheduled: 'warning',
+};
+
+const FormStatusBadge: React.FC<FormStatusBadgeProps> = ({status}) => {
+  const variant = STATUS_BADGE_VARIANTS[status];
+  return (
+    <Badge variant={variant}>
+      <FormattedMessage {...STATUS_LABELS[status]} />
+    </Badge>
+  );
+};
+
+export default FormStatusBadge;

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -1,0 +1,4 @@
+import EnvironmentBadge from './EnvironmentBadge';
+import FormStatusBadge from './FormStatusBadge';
+
+export {EnvironmentBadge, FormStatusBadge};

--- a/src/components/layout/BasicLayout.stories.tsx
+++ b/src/components/layout/BasicLayout.stories.tsx
@@ -3,6 +3,7 @@ import {reactRouterParameters, withRouter} from 'storybook-addon-remix-react-rou
 
 import BasicLayout from '@/components/layout/BasicLayout';
 import type {RouteHandle} from '@/routes/types';
+import {withAdminSettingsProvider} from '@/sb-decorators';
 
 const SimplePageContent = () => (
   <div>
@@ -17,7 +18,7 @@ export default {
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [withRouter],
+  decorators: [withRouter, withAdminSettingsProvider],
 } satisfies Meta<typeof BasicLayout>;
 
 type Story = StoryObj<typeof BasicLayout>;

--- a/src/components/layout/BasicLayout.stories.tsx
+++ b/src/components/layout/BasicLayout.stories.tsx
@@ -3,7 +3,6 @@ import {reactRouterParameters, withRouter} from 'storybook-addon-remix-react-rou
 
 import BasicLayout from '@/components/layout/BasicLayout';
 import type {RouteHandle} from '@/routes/types';
-import {withAdminSettingsProvider} from '@/sb-decorators';
 
 const SimplePageContent = () => (
   <div>
@@ -18,7 +17,7 @@ export default {
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [withRouter, withAdminSettingsProvider],
+  decorators: [withRouter],
 } satisfies Meta<typeof BasicLayout>;
 
 type Story = StoryObj<typeof BasicLayout>;

--- a/src/components/layout/BasicLayout.tsx
+++ b/src/components/layout/BasicLayout.tsx
@@ -1,14 +1,22 @@
-import {Body, CardBaseTemplate, Column, Logo, Outline, Toolbar} from '@maykin-ui/admin-ui';
+import {
+  Body,
+  Breadcrumbs,
+  CardBaseTemplate,
+  Column,
+  Logo,
+  Outline,
+  Toolbar,
+} from '@maykin-ui/admin-ui';
 import '@maykin-ui/admin-ui/style';
 import {Outlet} from 'react-router';
 
+import {EnvironmentBadge, FormStatusBadge} from '@/components/badge';
 import {useBreadcrumbItems} from '@/hooks/useBreadcrumbItems';
 
 const BasicLayout = () => {
   const breadcrumbItems = useBreadcrumbItems();
   return (
     <CardBaseTemplate
-      breadcrumbItems={breadcrumbItems}
       primaryNavigationItems={[
         <Logo key="Logo" abbreviated />,
         'spacer',
@@ -55,6 +63,25 @@ const BasicLayout = () => {
         },
       ]}
     >
+      <Toolbar
+        align="space-between"
+        direction="horizontal"
+        pad
+        items={[
+          <Breadcrumbs key="breadcrumbs" items={breadcrumbItems} />,
+          <Toolbar
+            key="badges"
+            direction="horizontal"
+            pad={false}
+            justify={false}
+            items={[
+              <EnvironmentBadge key="environment-badge" />,
+              // Dynamically show/hide badge and set status
+              <FormStatusBadge key="form-status-badge" status={'active'} />,
+            ]}
+          />,
+        ]}
+      />
       <Body fullHeight>
         <Outlet />
       </Body>

--- a/src/context/AdminSettingsProvider.tsx
+++ b/src/context/AdminSettingsProvider.tsx
@@ -1,12 +1,13 @@
 import {AdminSettingsContext} from './context';
+import type {AdminSettings} from './context';
 
-export interface AdminSettingsProviderProps {
-  environment?: string;
-  children?: React.ReactNode;
-}
-
-const AdminSettingsProvider: React.FC<AdminSettingsProviderProps> = ({environment, children}) => (
-  <AdminSettingsContext.Provider value={{environment}}>{children}</AdminSettingsContext.Provider>
+const AdminSettingsProvider: React.FC<React.PropsWithChildren<AdminSettings>> = ({
+  environmentInfo,
+  children,
+}) => (
+  <AdminSettingsContext.Provider value={{environmentInfo}}>
+    {children}
+  </AdminSettingsContext.Provider>
 );
 
 export default AdminSettingsProvider;

--- a/src/context/AdminSettingsProvider.tsx
+++ b/src/context/AdminSettingsProvider.tsx
@@ -1,0 +1,12 @@
+import {AdminSettingsContext} from './context';
+
+export interface AdminSettingsProviderProps {
+  environment?: string;
+  children?: React.ReactNode;
+}
+
+const AdminSettingsProvider: React.FC<AdminSettingsProviderProps> = ({environment, children}) => (
+  <AdminSettingsContext.Provider value={{environment}}>{children}</AdminSettingsContext.Provider>
+);
+
+export default AdminSettingsProvider;

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -2,12 +2,23 @@ import React from 'react';
 
 export interface AdminSettings {
   /**
-   * The environment name of the Open Forms instance.
+   * Configuration for the Open Forms environment.
+   *
+   * The configuration is based on the OF backend environment variables for the
+   * environment name and badge colors.
+   * See https://open-forms.readthedocs.io/en/stable/installation/config.html#other-settings
    */
-  environment?: string;
+  environmentInfo: {
+    label: string;
+    showBadge: boolean;
+    backgroundColor?: string;
+    foregroundColor?: string;
+  };
 }
 
-const AdminSettingsContext = React.createContext<AdminSettings>({});
+const AdminSettingsContext = React.createContext<AdminSettings>({
+  environmentInfo: {label: '', showBadge: true},
+});
 
 AdminSettingsContext.displayName = 'AdminSettingsContext';
 

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export interface AdminSettings {
+  /**
+   * The environment name of the Open Forms instance.
+   */
+  environment?: string;
+}
+
+const AdminSettingsContext = React.createContext<AdminSettings>({});
+
+AdminSettingsContext.displayName = 'AdminSettingsContext';
+
+export {AdminSettingsContext};

--- a/src/hooks/useAdminSettings.ts
+++ b/src/hooks/useAdminSettings.ts
@@ -1,0 +1,5 @@
+import {useContext} from 'react';
+
+import {AdminSettingsContext} from '@/context/context';
+
+export const useAdminSettings = () => useContext(AdminSettingsContext);

--- a/src/type-fixes.d.ts
+++ b/src/type-fixes.d.ts
@@ -1,0 +1,6 @@
+// See: https://stackoverflow.com/a/70398145
+declare namespace React {
+  interface CSSProperties {
+    [key: `--${string}`]: string | number;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "resolveJsonModule": true,
     "noErrorTruncation": true,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@/sb-decorators": ["../.storybook/decorators.tsx"]
     },
     "skipLibCheck": true
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,11 @@ export default defineConfig(({mode}) => ({
     }),
     dts({tsconfigPath: './tsconfig.prod.json'}),
   ],
+  resolve: {
+    alias: {
+      '@/components': resolve(_OF_INTERNAL_dirname, 'src/components'),
+    },
+  },
   css: {
     preprocessorOptions: {
       scss: {quietDeps: true},

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,11 @@
 import {setProjectAnnotations} from '@storybook/react-vite';
+import * as reactIntlAnnotations from 'storybook-react-intl/preview';
+import {beforeAll} from 'vitest';
 
 import * as projectAnnotations from './.storybook/preview';
 
 // This is an important step to apply the right configuration when testing your stories.
 // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
-setProjectAnnotations([projectAnnotations]);
+const annotations = setProjectAnnotations([reactIntlAnnotations, projectAnnotations]);
+
+beforeAll(annotations.beforeAll);


### PR DESCRIPTION
Closes #8

Adding badge components for form status and admin environment.

The environment badge uses a `AdminSettingsContext` to fetch the current environment name.

The form status badge is currently very simplistic. It takes an `status` argument, which is used to set the styling and content of the badge. Currently an already existing theme of the admin-ui is being used, so the styling of the form status badges isn't conform the design.

When we update the admin-ui dependency, and use the newly defined theme, the badge styling will be updated and will follow the design.

Also some minor imperfections are left, like spacing details between admin-ui components. This is due to differences between the design and the current admin-ui capabilities. These details will be picked-up at a later moment