### PR TITLE
Updating admin-ui dependency and themes

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,6 @@
 import '@maykin-ui/admin-ui/style';
-// @TODO update theme after upgrading admin-ui
-import '@maykin-ui/admin-ui/style/themes/purple-rain.css';
+import '@maykin-ui/admin-ui/style/themes/black-night.css';
+import '@maykin-ui/admin-ui/style/themes/purple-haze.css';
 import type {Preview} from '@storybook/react-vite';
 
 import {withAdminSettingsProvider} from '@/sb-decorators';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@maykin-ui/admin-ui": "^2.0.0-beta.2",
+        "@maykin-ui/admin-ui": "^3.0.0-alpha.1",
         "@tanstack/react-query": "^5.90.16",
         "react-router": "^7.12.0"
       },
@@ -1619,9 +1619,9 @@
       }
     },
     "node_modules/@maykin-ui/admin-ui": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@maykin-ui/admin-ui/-/admin-ui-2.0.0-beta.2.tgz",
-      "integrity": "sha512-7fBBuMyknE7p6YDCFOL06IReHyY0aXKN6NlXmw88XBcKbaRRxVLQnSkUxG2jt4QFgPXBsLlyLW0o6q77FhY1rQ==",
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@maykin-ui/admin-ui/-/admin-ui-3.0.0-alpha.1.tgz",
+      "integrity": "sha512-yIFPmFyZMglAPO7BOzclhiMcp1sdDKiGx8WZ+bCbnbtQjoxkoBs9vKClChqLnbxx0gfY3dNwNhukyeV1Znnn4g==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.5",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "vitest-browser-react": "^2.0.2"
   },
   "dependencies": {
-    "@maykin-ui/admin-ui": "^2.0.0-beta.2",
+    "@maykin-ui/admin-ui": "^3.0.0-alpha.1",
     "@tanstack/react-query": "^5.90.16",
     "react-router": "^7.12.0"
   }

--- a/src/AdminUI.tsx
+++ b/src/AdminUI.tsx
@@ -1,6 +1,6 @@
 import '@maykin-ui/admin-ui/style';
-// @TODO update theme after upgrading admin-ui
-import '@maykin-ui/admin-ui/style/themes/purple-rain.css';
+import '@maykin-ui/admin-ui/style/themes/black-night.css';
+import '@maykin-ui/admin-ui/style/themes/purple-haze.css';
 import React from 'react';
 import {RouterProvider, createBrowserRouter} from 'react-router';
 

--- a/src/components/layout/BasicLayout.tsx
+++ b/src/components/layout/BasicLayout.tsx
@@ -7,7 +7,6 @@ import {
   Outline,
   Toolbar,
 } from '@maykin-ui/admin-ui';
-import '@maykin-ui/admin-ui/style';
 import {Outlet} from 'react-router';
 
 import {EnvironmentBadge, FormStatusBadge} from '@/components/badge';


### PR DESCRIPTION
Closes #19 

Upgrading the Maykin admin-ui to version 3.0.0-alpha-1 and using the new `purple-haze` and `black-night` themes.