### PR TITLE
Admin navigation

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -143,3 +143,26 @@ export const withFormLayout: Decorator = (Story, {parameters}) => {
     </QueryClientProvider>
   );
 };
+
+/**
+ * A decorator that sets up MSW handlers before creating the React Router.
+ *
+ * When requests are performed using the React-router loader, the regular WithRouter
+ * initializes the msw handlers after the loader request. This decorator ensures that the
+ * MSW handlers are registered before the router is created.
+ */
+export const withMswRouter: Decorator = (_, context) => {
+  const storyHandlers = context.parameters?.msw?.handlers ?? [];
+  const reactRouter = context.parameters?.reactRouter ?? {};
+
+  // Register story handlers BEFORE router is created
+  if (storyHandlers.length > 0) {
+    mswWorker.use(...storyHandlers);
+  }
+
+  const router = createMemoryRouter([reactRouter.routing], {
+    initialEntries: [reactRouter.location.path ?? '/'],
+  });
+
+  return <RouterProvider router={router} />;
+};

--- a/i18n/compiled/en.json
+++ b/i18n/compiled/en.json
@@ -1,4 +1,22 @@
 {
+  "23y84q": [
+    {
+      "type": 0,
+      "value": "Confirmation"
+    }
+  ],
+  "2TGIP7": [
+    {
+      "type": 0,
+      "value": "Login"
+    }
+  ],
+  "2Ud2Cc": [
+    {
+      "type": 0,
+      "value": "Form rules"
+    }
+  ],
   "2vFy0E": [
     {
       "type": 0,
@@ -11,10 +29,46 @@
       "value": "Preview"
     }
   ],
+  "3dh+h1": [
+    {
+      "type": 0,
+      "value": "Translations"
+    }
+  ],
+  "465GuA": [
+    {
+      "type": 0,
+      "value": "Settings"
+    }
+  ],
+  "4QxfrT": [
+    {
+      "type": 0,
+      "value": "Introduction page"
+    }
+  ],
   "6UFbVC": [
     {
       "type": 0,
       "value": "There was an authentication problem."
+    }
+  ],
+  "8CNXuR": [
+    {
+      "type": 0,
+      "value": "Submissions"
+    }
+  ],
+  "91B589": [
+    {
+      "type": 0,
+      "value": "Payment"
+    }
+  ],
+  "9Hn0fj": [
+    {
+      "type": 0,
+      "value": "Variables"
     }
   ],
   "9eNQrq": [
@@ -55,6 +109,12 @@
       "value": "isRequired"
     }
   ],
+  "9ereUQ": [
+    {
+      "type": 0,
+      "value": "Forms"
+    }
+  ],
   "BfpzoP": [
     {
       "type": 0,
@@ -65,6 +125,30 @@
     {
       "type": 0,
       "value": "Form submission statistics"
+    }
+  ],
+  "F5wcwK": [
+    {
+      "type": 0,
+      "value": "Confirmation"
+    }
+  ],
+  "FDqOKN": [
+    {
+      "type": 0,
+      "value": "Prefill"
+    }
+  ],
+  "FVCVno": [
+    {
+      "type": 0,
+      "value": "Registration"
+    }
+  ],
+  "IHI3xy": [
+    {
+      "type": 0,
+      "value": "Information"
     }
   ],
   "JX8BYx": [
@@ -85,10 +169,28 @@
       "value": "Go to the login page"
     }
   ],
+  "KvV9iL": [
+    {
+      "type": 0,
+      "value": "Form steps"
+    }
+  ],
   "NJ3Psx": [
     {
       "type": 0,
       "value": "Your session has expired."
+    }
+  ],
+  "PN3JMo": [
+    {
+      "type": 0,
+      "value": "Availability"
+    }
+  ],
+  "PWu0qX": [
+    {
+      "type": 0,
+      "value": "Forms"
     }
   ],
   "Qroj81": [
@@ -103,6 +205,24 @@
       "value": "Save"
     }
   ],
+  "UIKEnY": [
+    {
+      "type": 0,
+      "value": "User variables"
+    }
+  ],
+  "YbQaJ0": [
+    {
+      "type": 0,
+      "value": "Library rules"
+    }
+  ],
+  "ZMsrHL": [
+    {
+      "type": 0,
+      "value": "Categories"
+    }
+  ],
   "ZiDANM": [
     {
       "type": 0,
@@ -115,16 +235,64 @@
       "value": "Design"
     }
   ],
+  "csfzAx": [
+    {
+      "type": 0,
+      "value": "History"
+    }
+  ],
+  "dTtQ0W": [
+    {
+      "type": 0,
+      "value": "Forms"
+    }
+  ],
   "e/VFua": [
     {
       "type": 0,
       "value": "Active form"
     }
   ],
+  "eJZabQ": [
+    {
+      "type": 0,
+      "value": "Add new step"
+    }
+  ],
+  "f5KoHj": [
+    {
+      "type": 0,
+      "value": "Presentation"
+    }
+  ],
+  "fGylQR": [
+    {
+      "type": 0,
+      "value": "Design"
+    }
+  ],
+  "fdVayh": [
+    {
+      "type": 0,
+      "value": "Start page"
+    }
+  ],
+  "jThIo3": [
+    {
+      "type": 0,
+      "value": "Form statistics"
+    }
+  ],
   "nxMx4O": [
     {
       "type": 0,
       "value": "Authentication problem"
+    }
+  ],
+  "nxYozh": [
+    {
+      "type": 0,
+      "value": "Search in settings"
     }
   ],
   "pJ2Kxl": [
@@ -139,16 +307,34 @@
       "value": "Settings"
     }
   ],
+  "qF9GQ2": [
+    {
+      "type": 0,
+      "value": "Logic"
+    }
+  ],
   "rZfe8Z": [
     {
       "type": 0,
       "value": "Sorry, we couldn't do that because you are logged out - this may be because your session expired."
     }
   ],
+  "t2hC8j": [
+    {
+      "type": 0,
+      "value": "Add new logic rule"
+    }
+  ],
   "t5YtWB": [
     {
       "type": 0,
       "value": "Inactive form"
+    }
+  ],
+  "xGHW+D": [
+    {
+      "type": 0,
+      "value": "Data removal"
     }
   ],
   "zEFFxg": [

--- a/i18n/compiled/nl.json
+++ b/i18n/compiled/nl.json
@@ -1,4 +1,22 @@
 {
+  "23y84q": [
+    {
+      "type": 0,
+      "value": "Bevestiging"
+    }
+  ],
+  "2TGIP7": [
+    {
+      "type": 0,
+      "value": "Inloggen"
+    }
+  ],
+  "2Ud2Cc": [
+    {
+      "type": 0,
+      "value": "Formulier regels"
+    }
+  ],
   "2vFy0E": [
     {
       "type": 0,
@@ -11,10 +29,46 @@
       "value": "Preview"
     }
   ],
+  "3dh+h1": [
+    {
+      "type": 0,
+      "value": "Vertalingen"
+    }
+  ],
+  "465GuA": [
+    {
+      "type": 0,
+      "value": "Instellingen"
+    }
+  ],
+  "4QxfrT": [
+    {
+      "type": 0,
+      "value": "Introductiepagina"
+    }
+  ],
   "6UFbVC": [
     {
       "type": 0,
       "value": "Je moet ingelogd zijn voor deze actie."
+    }
+  ],
+  "8CNXuR": [
+    {
+      "type": 0,
+      "value": "Inzendingen"
+    }
+  ],
+  "91B589": [
+    {
+      "type": 0,
+      "value": "Betaling"
+    }
+  ],
+  "9Hn0fj": [
+    {
+      "type": 0,
+      "value": "Variabelen"
     }
   ],
   "9eNQrq": [
@@ -55,6 +109,12 @@
       "value": "isRequired"
     }
   ],
+  "9ereUQ": [
+    {
+      "type": 0,
+      "value": "Formulieren"
+    }
+  ],
   "BfpzoP": [
     {
       "type": 0,
@@ -65,6 +125,30 @@
     {
       "type": 0,
       "value": "Inzendingstatistieken"
+    }
+  ],
+  "F5wcwK": [
+    {
+      "type": 0,
+      "value": "Bevestiging"
+    }
+  ],
+  "FDqOKN": [
+    {
+      "type": 0,
+      "value": "Prefill"
+    }
+  ],
+  "FVCVno": [
+    {
+      "type": 0,
+      "value": "Registratie"
+    }
+  ],
+  "IHI3xy": [
+    {
+      "type": 0,
+      "value": "Informatie"
     }
   ],
   "JX8BYx": [
@@ -85,10 +169,28 @@
       "value": "Ga naar de login pagina"
     }
   ],
+  "KvV9iL": [
+    {
+      "type": 0,
+      "value": "Formulier stappen"
+    }
+  ],
   "NJ3Psx": [
     {
       "type": 0,
       "value": "Je sessie is verlopen."
+    }
+  ],
+  "PN3JMo": [
+    {
+      "type": 0,
+      "value": "Beschikbaarheid"
+    }
+  ],
+  "PWu0qX": [
+    {
+      "type": 0,
+      "value": "Formulieren"
     }
   ],
   "Qroj81": [
@@ -103,6 +205,24 @@
       "value": "Opslaan"
     }
   ],
+  "UIKEnY": [
+    {
+      "type": 0,
+      "value": "Gebruikersvariabelen"
+    }
+  ],
+  "YbQaJ0": [
+    {
+      "type": 0,
+      "value": "Bibliotheek regels"
+    }
+  ],
+  "ZMsrHL": [
+    {
+      "type": 0,
+      "value": "Categorieën"
+    }
+  ],
   "ZiDANM": [
     {
       "type": 0,
@@ -115,16 +235,64 @@
       "value": "Ontwerpen"
     }
   ],
+  "csfzAx": [
+    {
+      "type": 0,
+      "value": "Geschiedenis"
+    }
+  ],
+  "dTtQ0W": [
+    {
+      "type": 0,
+      "value": "Formulieren"
+    }
+  ],
   "e/VFua": [
     {
       "type": 0,
       "value": "Formulier actief"
     }
   ],
+  "eJZabQ": [
+    {
+      "type": 0,
+      "value": "Nieuwe stap toevoegen"
+    }
+  ],
+  "f5KoHj": [
+    {
+      "type": 0,
+      "value": "Weergave"
+    }
+  ],
+  "fGylQR": [
+    {
+      "type": 0,
+      "value": "Ontwerpen"
+    }
+  ],
+  "fdVayh": [
+    {
+      "type": 0,
+      "value": "Startpagina"
+    }
+  ],
+  "jThIo3": [
+    {
+      "type": 0,
+      "value": "Inzendingstatistieken"
+    }
+  ],
   "nxMx4O": [
     {
       "type": 0,
       "value": "Inlogprobleem"
+    }
+  ],
+  "nxYozh": [
+    {
+      "type": 0,
+      "value": "Zoek in instellingen"
     }
   ],
   "pJ2Kxl": [
@@ -139,16 +307,34 @@
       "value": "Instellingen"
     }
   ],
+  "qF9GQ2": [
+    {
+      "type": 0,
+      "value": "Logica"
+    }
+  ],
   "rZfe8Z": [
     {
       "type": 0,
       "value": "Excuses, we konden deze actie niet uitvoeren omdat u uitgelogd bent. Uw sessie is waarschijnlijk vervallen."
     }
   ],
+  "t2hC8j": [
+    {
+      "type": 0,
+      "value": "Nieuwe logica regel toevoegen"
+    }
+  ],
   "t5YtWB": [
     {
       "type": 0,
       "value": "Formulier niet actief"
+    }
+  ],
+  "xGHW+D": [
+    {
+      "type": 0,
+      "value": "Bewaartermijn"
     }
   ],
   "zEFFxg": [

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -1,4 +1,19 @@
 {
+  "23y84q": {
+    "defaultMessage": "Confirmation",
+    "description": "Main navigation label 'confirmation'",
+    "originalDefault": "Confirmation"
+  },
+  "2TGIP7": {
+    "defaultMessage": "Login",
+    "description": "Main navigation label 'authentication settings'",
+    "originalDefault": "Login"
+  },
+  "2Ud2Cc": {
+    "defaultMessage": "Form rules",
+    "description": "Main navigation label 'form rules'",
+    "originalDefault": "Form rules"
+  },
   "2vFy0E": {
     "defaultMessage": "Categories",
     "description": "Route breadcrumb label for form categories",
@@ -9,15 +24,50 @@
     "description": "Preview button text",
     "originalDefault": "Preview"
   },
+  "3dh+h1": {
+    "defaultMessage": "Translations",
+    "description": "Main navigation label 'translations settings'",
+    "originalDefault": "Translations"
+  },
+  "465GuA": {
+    "defaultMessage": "Settings",
+    "description": "Main navigation label 'form settings'",
+    "originalDefault": "Settings"
+  },
+  "4QxfrT": {
+    "defaultMessage": "Introduction page",
+    "description": "Main navigation label 'form introduction page'",
+    "originalDefault": "Introduction page"
+  },
   "6UFbVC": {
     "defaultMessage": "There was an authentication problem.",
     "description": "'Not authenticated' error message",
     "originalDefault": "There was an authentication problem."
   },
+  "8CNXuR": {
+    "defaultMessage": "Submissions",
+    "description": "Main navigation label 'submissions settings'",
+    "originalDefault": "Submissions"
+  },
+  "91B589": {
+    "defaultMessage": "Payment",
+    "description": "Main navigation label 'payment settings'",
+    "originalDefault": "Payment"
+  },
+  "9Hn0fj": {
+    "defaultMessage": "Variables",
+    "description": "Main navigation label 'variables settings'",
+    "originalDefault": "Variables"
+  },
   "9eNQrq": {
     "defaultMessage": "{isRequired, select, true {{label} <span>Required</span>} other {{label}} }",
     "description": "Form field label content/wrapper",
     "originalDefault": "{isRequired, select, true {{label} <span>Required</span>} other {{label}} }"
+  },
+  "9ereUQ": {
+    "defaultMessage": "Forms",
+    "description": "Main navigation label 'forms overview'",
+    "originalDefault": "Forms"
   },
   "BfpzoP": {
     "defaultMessage": "Scheduled form",
@@ -28,6 +78,26 @@
     "defaultMessage": "Form submission statistics",
     "description": "Route breadcrumb label for form submission statistics",
     "originalDefault": "form submission statistics"
+  },
+  "F5wcwK": {
+    "defaultMessage": "Confirmation",
+    "description": "Main navigation label 'confirmation settings'",
+    "originalDefault": "Confirmation"
+  },
+  "FDqOKN": {
+    "defaultMessage": "Prefill",
+    "description": "Main navigation label 'prefill settings'",
+    "originalDefault": "Prefill"
+  },
+  "FVCVno": {
+    "defaultMessage": "Registration",
+    "description": "Main navigation label 'registration settings'",
+    "originalDefault": "Registration"
+  },
+  "IHI3xy": {
+    "defaultMessage": "Information",
+    "description": "Main navigation label 'general settings'",
+    "originalDefault": "Information"
   },
   "JX8BYx": {
     "defaultMessage": "Unfortunately something went wrong!",
@@ -44,10 +114,25 @@
     "description": "'Go to login page' link text",
     "originalDefault": "Go to the login page"
   },
+  "KvV9iL": {
+    "defaultMessage": "Form steps",
+    "description": "Main navigation label 'form steps page'",
+    "originalDefault": "Form steps"
+  },
   "NJ3Psx": {
     "defaultMessage": "Your session has expired.",
     "description": "Session expiry notice - expired",
     "originalDefault": "Your session has expired."
+  },
+  "PN3JMo": {
+    "defaultMessage": "Availability",
+    "description": "Main navigation label 'availability settings'",
+    "originalDefault": "Availability"
+  },
+  "PWu0qX": {
+    "defaultMessage": "Forms",
+    "description": "Main navigation label 'form subject'",
+    "originalDefault": "Forms"
   },
   "Qroj81": {
     "defaultMessage": "Forms",
@@ -59,6 +144,21 @@
     "description": "Save button text",
     "originalDefault": "Save"
   },
+  "UIKEnY": {
+    "defaultMessage": "User variables",
+    "description": "Main navigation label 'user variables'",
+    "originalDefault": "User variables"
+  },
+  "YbQaJ0": {
+    "defaultMessage": "Library rules",
+    "description": "Main navigation label 'library rules'",
+    "originalDefault": "Library rules"
+  },
+  "ZMsrHL": {
+    "defaultMessage": "Categories",
+    "description": "Main navigation label 'form categories'",
+    "originalDefault": "Categories"
+  },
   "ZiDANM": {
     "defaultMessage": "Home",
     "description": "Route breadcrumb label for home",
@@ -69,15 +169,55 @@
     "description": "Route breadcrumb label for form detail design",
     "originalDefault": "design"
   },
+  "csfzAx": {
+    "defaultMessage": "History",
+    "description": "Main navigation label 'history settings'",
+    "originalDefault": "History"
+  },
+  "dTtQ0W": {
+    "defaultMessage": "Forms",
+    "description": "Main navigation label 'back to forms'",
+    "originalDefault": "Forms"
+  },
   "e/VFua": {
     "defaultMessage": "Active form",
     "description": "Label for form status \"active\"",
     "originalDefault": "Active form"
   },
+  "eJZabQ": {
+    "defaultMessage": "Add new step",
+    "description": "Main navigation label 'add form step'",
+    "originalDefault": "Add new step"
+  },
+  "f5KoHj": {
+    "defaultMessage": "Presentation",
+    "description": "Main navigation label 'presentation settings'",
+    "originalDefault": "Presentation"
+  },
+  "fGylQR": {
+    "defaultMessage": "Design",
+    "description": "Main navigation label 'form design'",
+    "originalDefault": "Design"
+  },
+  "fdVayh": {
+    "defaultMessage": "Start page",
+    "description": "Main navigation label 'form start page'",
+    "originalDefault": "Start page"
+  },
+  "jThIo3": {
+    "defaultMessage": "Form statistics",
+    "description": "Main navigation label 'form statistics'",
+    "originalDefault": "Form statistics"
+  },
   "nxMx4O": {
     "defaultMessage": "Authentication problem",
     "description": "'Not authenticated' error title",
     "originalDefault": "Authentication problem"
+  },
+  "nxYozh": {
+    "defaultMessage": "Search in settings",
+    "description": "Settings navigation search input aria label",
+    "originalDefault": "Search in settings"
   },
   "pJ2Kxl": {
     "defaultMessage": "Form in maintenance mode",
@@ -89,15 +229,30 @@
     "description": "Route breadcrumb label for form detail settings",
     "originalDefault": "settings"
   },
+  "qF9GQ2": {
+    "defaultMessage": "Logic",
+    "description": "Main navigation label 'form logic'",
+    "originalDefault": "Logic"
+  },
   "rZfe8Z": {
     "defaultMessage": "Sorry, we couldn't do that because you are logged out - this may be because your session expired.",
     "description": "Session expiry notice - API call failed with 401",
     "originalDefault": "Sorry, we couldn't do that because you are logged out - this may be because your session expired."
   },
+  "t2hC8j": {
+    "defaultMessage": "Add new logic rule",
+    "description": "Main navigation label 'add logic rule'",
+    "originalDefault": "Add new logic rule"
+  },
   "t5YtWB": {
     "defaultMessage": "Inactive form",
     "description": "Label for form status \"inactive\"",
     "originalDefault": "Inactive form"
+  },
+  "xGHW+D": {
+    "defaultMessage": "Data removal",
+    "description": "Main navigation label 'data removal settings'",
+    "originalDefault": "Data removal"
   },
   "zEFFxg": {
     "defaultMessage": "Oops!",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -1,4 +1,19 @@
 {
+  "23y84q": {
+    "defaultMessage": "Bevestiging",
+    "description": "Main navigation label 'confirmation'",
+    "originalDefault": "Confirmation"
+  },
+  "2TGIP7": {
+    "defaultMessage": "Inloggen",
+    "description": "Main navigation label 'authentication settings'",
+    "originalDefault": "Login"
+  },
+  "2Ud2Cc": {
+    "defaultMessage": "Formulier regels",
+    "description": "Main navigation label 'form rules'",
+    "originalDefault": "Form rules"
+  },
   "2vFy0E": {
     "defaultMessage": "Categorieën",
     "description": "Route breadcrumb label for form categories",
@@ -10,15 +25,50 @@
     "isTranslated": true,
     "originalDefault": "Preview"
   },
+  "3dh+h1": {
+    "defaultMessage": "Vertalingen",
+    "description": "Main navigation label 'translations settings'",
+    "originalDefault": "Translations"
+  },
+  "465GuA": {
+    "defaultMessage": "Instellingen",
+    "description": "Main navigation label 'form settings'",
+    "originalDefault": "Settings"
+  },
+  "4QxfrT": {
+    "defaultMessage": "Introductiepagina",
+    "description": "Main navigation label 'form introduction page'",
+    "originalDefault": "Introduction page"
+  },
   "6UFbVC": {
     "defaultMessage": "Je moet ingelogd zijn voor deze actie.",
     "description": "'Not authenticated' error message",
     "originalDefault": "There was an authentication problem."
   },
+  "8CNXuR": {
+    "defaultMessage": "Inzendingen",
+    "description": "Main navigation label 'submissions settings'",
+    "originalDefault": "Submissions"
+  },
+  "91B589": {
+    "defaultMessage": "Betaling",
+    "description": "Main navigation label 'payment settings'",
+    "originalDefault": "Payment"
+  },
+  "9Hn0fj": {
+    "defaultMessage": "Variabelen",
+    "description": "Main navigation label 'variables settings'",
+    "originalDefault": "Variables"
+  },
   "9eNQrq": {
     "defaultMessage": "{isRequired, select, true {{label} <span>Verplicht</span>} other {{label}} }",
     "description": "Form field label content/wrapper",
     "originalDefault": "{isRequired, select, true {{label} <span>Required</span>} other {{label}} }"
+  },
+  "9ereUQ": {
+    "defaultMessage": "Formulieren",
+    "description": "Main navigation label 'forms overview'",
+    "originalDefault": "Forms"
   },
   "BfpzoP": {
     "defaultMessage": "Formulier ingepland",
@@ -29,6 +79,27 @@
     "defaultMessage": "Inzendingstatistieken",
     "description": "Route breadcrumb label for form submission statistics",
     "originalDefault": "form submission statistics"
+  },
+  "F5wcwK": {
+    "defaultMessage": "Bevestiging",
+    "description": "Main navigation label 'confirmation settings'",
+    "originalDefault": "Confirmation"
+  },
+  "FDqOKN": {
+    "defaultMessage": "Prefill",
+    "description": "Main navigation label 'prefill settings'",
+    "isTranslated": true,
+    "originalDefault": "Prefill"
+  },
+  "FVCVno": {
+    "defaultMessage": "Registratie",
+    "description": "Main navigation label 'registration settings'",
+    "originalDefault": "Registration"
+  },
+  "IHI3xy": {
+    "defaultMessage": "Informatie",
+    "description": "Main navigation label 'general settings'",
+    "originalDefault": "Information"
   },
   "JX8BYx": {
     "defaultMessage": "Er ging helaas iets fout!",
@@ -45,10 +116,25 @@
     "description": "'Go to login page' link text",
     "originalDefault": "Go to the login page"
   },
+  "KvV9iL": {
+    "defaultMessage": "Formulier stappen",
+    "description": "Main navigation label 'form steps page'",
+    "originalDefault": "Form steps"
+  },
   "NJ3Psx": {
     "defaultMessage": "Je sessie is verlopen.",
     "description": "Session expiry notice - expired",
     "originalDefault": "Your session has expired."
+  },
+  "PN3JMo": {
+    "defaultMessage": "Beschikbaarheid",
+    "description": "Main navigation label 'availability settings'",
+    "originalDefault": "Availability"
+  },
+  "PWu0qX": {
+    "defaultMessage": "Formulieren",
+    "description": "Main navigation label 'form subject'",
+    "originalDefault": "Forms"
   },
   "Qroj81": {
     "defaultMessage": "Formulieren",
@@ -60,6 +146,21 @@
     "description": "Save button text",
     "originalDefault": "Save"
   },
+  "UIKEnY": {
+    "defaultMessage": "Gebruikersvariabelen",
+    "description": "Main navigation label 'user variables'",
+    "originalDefault": "User variables"
+  },
+  "YbQaJ0": {
+    "defaultMessage": "Bibliotheek regels",
+    "description": "Main navigation label 'library rules'",
+    "originalDefault": "Library rules"
+  },
+  "ZMsrHL": {
+    "defaultMessage": "Categorieën",
+    "description": "Main navigation label 'form categories'",
+    "originalDefault": "Categories"
+  },
   "ZiDANM": {
     "defaultMessage": "Home",
     "description": "Route breadcrumb label for home",
@@ -70,15 +171,55 @@
     "description": "Route breadcrumb label for form detail design",
     "originalDefault": "design"
   },
+  "csfzAx": {
+    "defaultMessage": "Geschiedenis",
+    "description": "Main navigation label 'history settings'",
+    "originalDefault": "History"
+  },
+  "dTtQ0W": {
+    "defaultMessage": "Formulieren",
+    "description": "Main navigation label 'back to forms'",
+    "originalDefault": "Forms"
+  },
   "e/VFua": {
     "defaultMessage": "Formulier actief",
     "description": "Label for form status \"active\"",
     "originalDefault": "Active form"
   },
+  "eJZabQ": {
+    "defaultMessage": "Nieuwe stap toevoegen",
+    "description": "Main navigation label 'add form step'",
+    "originalDefault": "Add new step"
+  },
+  "f5KoHj": {
+    "defaultMessage": "Weergave",
+    "description": "Main navigation label 'presentation settings'",
+    "originalDefault": "Presentation"
+  },
+  "fGylQR": {
+    "defaultMessage": "Ontwerpen",
+    "description": "Main navigation label 'form design'",
+    "originalDefault": "Design"
+  },
+  "fdVayh": {
+    "defaultMessage": "Startpagina",
+    "description": "Main navigation label 'form start page'",
+    "originalDefault": "Start page"
+  },
+  "jThIo3": {
+    "defaultMessage": "Inzendingstatistieken",
+    "description": "Main navigation label 'form statistics'",
+    "originalDefault": "Form statistics"
+  },
   "nxMx4O": {
     "defaultMessage": "Inlogprobleem",
     "description": "'Not authenticated' error title",
     "originalDefault": "Authentication problem"
+  },
+  "nxYozh": {
+    "defaultMessage": "Zoek in instellingen",
+    "description": "Settings navigation search input aria label",
+    "originalDefault": "Search in settings"
   },
   "pJ2Kxl": {
     "defaultMessage": "Formulier in onderhoudsmodus",
@@ -90,15 +231,30 @@
     "description": "Route breadcrumb label for form detail settings",
     "originalDefault": "settings"
   },
+  "qF9GQ2": {
+    "defaultMessage": "Logica",
+    "description": "Main navigation label 'form logic'",
+    "originalDefault": "Logic"
+  },
   "rZfe8Z": {
     "defaultMessage": "Excuses, we konden deze actie niet uitvoeren omdat u uitgelogd bent. Uw sessie is waarschijnlijk vervallen.",
     "description": "Session expiry notice - API call failed with 401",
     "originalDefault": "Sorry, we couldn't do that because you are logged out - this may be because your session expired."
   },
+  "t2hC8j": {
+    "defaultMessage": "Nieuwe logica regel toevoegen",
+    "description": "Main navigation label 'add logic rule'",
+    "originalDefault": "Add new logic rule"
+  },
   "t5YtWB": {
     "defaultMessage": "Formulier niet actief",
     "description": "Label for form status \"inactive\"",
     "originalDefault": "Inactive form"
+  },
+  "xGHW+D": {
+    "defaultMessage": "Bewaartermijn",
+    "description": "Main navigation label 'data removal settings'",
+    "originalDefault": "Data removal"
   },
   "zEFFxg": {
     "defaultMessage": "Oeps!",

--- a/src/components/layout/BasicLayout.stories.tsx
+++ b/src/components/layout/BasicLayout.stories.tsx
@@ -91,7 +91,7 @@ export const WithDynamicBreadcrumbs: Story = {
             }),
             // Use the loaded data for the breadcrumb label
             handle: {
-              breadcrumbLabel: (_, data) => data.name,
+              breadcrumbLabel: data => data.name,
             } satisfies RouteHandle<{name: string}>,
           },
         ],

--- a/src/components/layout/BasicLayout.tsx
+++ b/src/components/layout/BasicLayout.tsx
@@ -10,6 +10,7 @@ import {
 import {Outlet} from 'react-router';
 
 import {EnvironmentBadge, FormStatusBadge} from '@/components/badge';
+import Sidebar from '@/components/menu/Sidebar';
 import {useBreadcrumbItems} from '@/hooks/useBreadcrumbItems';
 
 export interface BasicLayoutProps {
@@ -40,39 +41,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = ({footer, children}) => {
           children: <Outline.QuestionMarkCircleIcon />,
         },
       ]}
-      sidebarItems={[
-        {
-          align: 'start',
-          active: true,
-          variant: 'primary',
-          children: (
-            <>
-              <Outline.PencilSquareIcon />
-              Menu item 1
-            </>
-          ),
-        },
-        {
-          align: 'start',
-          variant: 'transparent',
-          children: (
-            <>
-              <Outline.ShareIcon />
-              Menu item 2
-            </>
-          ),
-        },
-        {
-          align: 'start',
-          variant: 'transparent',
-          children: (
-            <>
-              <Outline.Cog6ToothIcon />
-              Menu item 3
-            </>
-          ),
-        },
-      ]}
+      slotSidebar={<Sidebar />}
     >
       <Toolbar
         align="space-between"

--- a/src/components/menu/FormDetailMenu/FormDetailMenu.stories.tsx
+++ b/src/components/menu/FormDetailMenu/FormDetailMenu.stories.tsx
@@ -1,0 +1,36 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {reactRouterParameters, withRouter} from 'storybook-addon-remix-react-router';
+
+import routes from '@/routes/form';
+
+import FormDetailMenu from './FormDetailMenu';
+
+export default {
+  title: 'Internal API / Menu / Form Detail Menu',
+  decorators: [withRouter],
+  component: FormDetailMenu,
+  parameters: {
+    controls: {disable: true},
+    reactRouter: reactRouterParameters({
+      location: {
+        path: '/forms/123/design',
+      },
+      routing: {
+        id: 'forms',
+        path: 'forms',
+        element: <FormDetailMenu align="space-between" direction="v" />,
+        children: [
+          {
+            id: 'form-detail',
+            path: ':formId',
+            children: routes,
+          },
+        ],
+      },
+    }),
+  },
+} satisfies Meta<typeof FormDetailMenu>;
+
+type Story = StoryObj<typeof FormDetailMenu>;
+
+export const Default: Story = {};

--- a/src/components/menu/FormDetailMenu/FormDetailMenu.tsx
+++ b/src/components/menu/FormDetailMenu/FormDetailMenu.tsx
@@ -1,5 +1,5 @@
 import {Accordion, Button, Input, Outline, Toolbar} from '@maykin-ui/admin-ui';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import {generatePath, useMatches} from 'react-router';
 
 import {PageId} from '@/routes/constants';
@@ -8,8 +8,19 @@ import NavItem from '../NavItem';
 import type {MenuLevelProps} from '../types';
 
 const SearchInput: React.FC = () => {
+  const intl = useIntl();
   // @TODO search input logic
-  return <Input type="text" placeholder="Search" icon={<Outline.MagnifyingGlassIcon />} />;
+  return (
+    <Input
+      type="text"
+      placeholder="Search"
+      aria-label={intl.formatMessage({
+        description: 'Settings navigation search input aria label',
+        defaultMessage: 'Search in settings',
+      })}
+      icon={<Outline.MagnifyingGlassIcon />}
+    />
+  );
 };
 
 const AddFormStep: React.FC = () => {

--- a/src/components/menu/FormDetailMenu/FormDetailMenu.tsx
+++ b/src/components/menu/FormDetailMenu/FormDetailMenu.tsx
@@ -1,0 +1,347 @@
+import {Accordion, Button, Input, Outline, Toolbar} from '@maykin-ui/admin-ui';
+import {FormattedMessage} from 'react-intl';
+import {generatePath, useMatches} from 'react-router';
+
+import {PageId} from '@/routes/constants';
+
+import NavItem from '../NavItem';
+import type {MenuLevelProps} from '../types';
+
+const SearchInput: React.FC = () => {
+  // @TODO search input logic
+  return <Input type="text" placeholder="Search" icon={<Outline.MagnifyingGlassIcon />} />;
+};
+
+const AddFormStep: React.FC = () => {
+  // @TODO 'add form step' logic
+  return (
+    <Button variant="secondary">
+      <FormattedMessage
+        description="Main navigation label 'add form step'"
+        defaultMessage="Add new step"
+      />
+    </Button>
+  );
+};
+
+const AddLogicRule: React.FC = () => {
+  // @TODO 'add logic rule' logic
+  return (
+    <Button variant="secondary">
+      <FormattedMessage
+        description="Main navigation label 'add logic rule'"
+        defaultMessage="Add new logic rule"
+      />
+    </Button>
+  );
+};
+
+const FormSteps: React.FC = () => {
+  // @TODO get form steps from formik state
+  return (
+    <>
+      <NavItem to="#">Form step 1</NavItem>
+      <NavItem to="#">Form step 2</NavItem>
+    </>
+  );
+};
+
+const FormDetailMenu: React.FC<MenuLevelProps> = ({...toolbarProps}) => {
+  const matches = useMatches();
+  const formId = '123'; // @TODO Fetch the formId from the formik state
+
+  const isFormDesignActive = matches.some(m => m.id === PageId.FORM_DETAIL_DESIGN);
+  const isFormLogicActive = matches.some(m => m.id === PageId.FORM_DETAIL_LOGIC);
+  const isFormSettingsActive = matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS);
+
+  return (
+    <Toolbar
+      {...toolbarProps}
+      items={[
+        <NavItem
+          key="back-to-forms-overview"
+          to={generatePath('/forms')}
+          buttonProps={{size: 's', bold: true}}
+        >
+          <Outline.ArrowLeftIcon />
+          <FormattedMessage
+            description="Main navigation label 'back to forms'"
+            defaultMessage="Forms"
+          />
+        </NavItem>,
+
+        // Form design sub-menu
+        <Accordion
+          key="form-design"
+          variant={isFormDesignActive ? 'primary' : 'transparent'}
+          open={isFormDesignActive}
+          items={[
+            <AddFormStep key="add-form-step" />,
+            <NavItem
+              key="form-introduction-page"
+              to={generatePath('/forms/:formId/design/introduction-page', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_DESIGN_INTRODUCTION)}
+            >
+              <Outline.PencilSquareIcon />
+              <FormattedMessage
+                description="Main navigation label 'form introduction page'"
+                defaultMessage="Introduction page"
+              />
+            </NavItem>,
+            <NavItem
+              key="form-start-page"
+              to={generatePath('/forms/:formId/design/start-page', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_DESIGN_START)}
+            >
+              <Outline.PencilSquareIcon />
+              <FormattedMessage
+                description="Main navigation label 'form start page'"
+                defaultMessage="Start page"
+              />
+            </NavItem>,
+            <NavItem
+              key="form-steps"
+              to={generatePath('/forms/:formId/design/form-steps', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_DESIGN_FORM_STEPS)}
+            >
+              <Outline.ListBulletIcon />
+              <FormattedMessage
+                description="Main navigation label 'form steps page'"
+                defaultMessage="Form steps"
+              />
+            </NavItem>,
+            <FormSteps key="form-steps-list" />,
+            <NavItem
+              key="confirmation"
+              to={generatePath('/forms/:formId/design/confirmation', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_DESIGN_CONFIRMATION)}
+            >
+              <Outline.CheckIcon />
+              <FormattedMessage
+                description="Main navigation label 'confirmation'"
+                defaultMessage="Confirmation"
+              />
+            </NavItem>,
+          ]}
+        >
+          <Outline.PencilSquareIcon />
+          <FormattedMessage
+            description="Main navigation label 'form design'"
+            defaultMessage="Design"
+          />
+        </Accordion>,
+
+        // Form logic sub-menu
+        <Accordion
+          key="form-logic"
+          variant={isFormLogicActive ? 'primary' : 'transparent'}
+          open={isFormLogicActive}
+          items={[
+            <NavItem
+              key="form-rules"
+              to={generatePath('/forms/:formId/logic/form-rules', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_LOGIC_FORM_RULES)}
+            >
+              <Outline.ShareIcon />
+              <FormattedMessage
+                description="Main navigation label 'form rules'"
+                defaultMessage="Form rules"
+              />
+            </NavItem>,
+            matches.some(m => m.id === PageId.FORM_DETAIL_LOGIC_FORM_RULES) ? (
+              <AddLogicRule key="add-logic-rule" />
+            ) : null,
+            <NavItem
+              key="library-rules"
+              to={generatePath('/forms/:formId/logic/library', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_LOGIC_LIBRARY)}
+            >
+              <Outline.BookmarkIcon />
+              <FormattedMessage
+                description="Main navigation label 'library rules'"
+                defaultMessage="Library rules"
+              />
+            </NavItem>,
+            <NavItem
+              key="user-variables"
+              to={generatePath('/forms/:formId/logic/user-variables', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_LOGIC_USER_VARIABLES)}
+            >
+              <Outline.VariableIcon />
+              <FormattedMessage
+                description="Main navigation label 'user variables'"
+                defaultMessage="User variables"
+              />
+            </NavItem>,
+          ]}
+        >
+          <Outline.ShareIcon />
+          <FormattedMessage
+            description="Main navigation label 'form logic'"
+            defaultMessage="Logic"
+          />
+        </Accordion>,
+
+        // Form settings sub-menu
+        <Accordion
+          key="form-settings"
+          variant={isFormSettingsActive ? 'primary' : 'transparent'}
+          open={isFormSettingsActive}
+          items={[
+            <SearchInput key="search-input" />,
+            <NavItem
+              key="general"
+              to={generatePath('/forms/:formId/settings/general', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_GENERAL)}
+            >
+              <Outline.InformationCircleIcon />
+              <FormattedMessage
+                description="Main navigation label 'general settings'"
+                defaultMessage="Information"
+              />
+            </NavItem>,
+            <NavItem
+              key="authentication"
+              to={generatePath('/forms/:formId/settings/authentication', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_AUTHENTICATION)}
+            >
+              <Outline.ArrowRightOnRectangleIcon />
+              <FormattedMessage
+                description="Main navigation label 'authentication settings'"
+                defaultMessage="Login"
+              />
+            </NavItem>,
+            <NavItem
+              key="availability"
+              to={generatePath('/forms/:formId/settings/availability', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_AVAILABILITY)}
+            >
+              <Outline.CalendarIcon />
+              <FormattedMessage
+                description="Main navigation label 'availability settings'"
+                defaultMessage="Availability"
+              />
+            </NavItem>,
+            <NavItem
+              key="presentation"
+              to={generatePath('/forms/:formId/settings/presentation', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_PRESENTATION)}
+            >
+              <Outline.PencilIcon />
+              <FormattedMessage
+                description="Main navigation label 'presentation settings'"
+                defaultMessage="Presentation"
+              />
+            </NavItem>,
+            <NavItem
+              key="prefill"
+              to={generatePath('/forms/:formId/settings/prefill', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_PREFILL)}
+            >
+              <Outline.PencilSquareIcon />
+              <FormattedMessage
+                description="Main navigation label 'prefill settings'"
+                defaultMessage="Prefill"
+              />
+            </NavItem>,
+            <NavItem
+              key="variables"
+              to={generatePath('/forms/:formId/settings/variables', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_VARIABLES)}
+            >
+              <Outline.VariableIcon />
+              <FormattedMessage
+                description="Main navigation label 'variables settings'"
+                defaultMessage="Variables"
+              />
+            </NavItem>,
+            <NavItem
+              key="registration"
+              to={generatePath('/forms/:formId/settings/registration', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_REGISTRATION)}
+            >
+              <Outline.InboxArrowDownIcon />
+              <FormattedMessage
+                description="Main navigation label 'registration settings'"
+                defaultMessage="Registration"
+              />
+            </NavItem>,
+            <NavItem
+              key="confirmation"
+              to={generatePath('/forms/:formId/settings/confirmation', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_CONFIRMATION)}
+            >
+              <Outline.CheckIcon />
+              <FormattedMessage
+                description="Main navigation label 'confirmation settings'"
+                defaultMessage="Confirmation"
+              />
+            </NavItem>,
+            <NavItem
+              key="submissions"
+              to={generatePath('/forms/:formId/settings/submissions', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_SUBMISSIONS)}
+            >
+              <Outline.ArrowRightCircleIcon />
+              <FormattedMessage
+                description="Main navigation label 'submissions settings'"
+                defaultMessage="Submissions"
+              />
+            </NavItem>,
+            <NavItem
+              key="payment"
+              to={generatePath('/forms/:formId/settings/payment', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_PAYMENT)}
+            >
+              <Outline.CreditCardIcon />
+              <FormattedMessage
+                description="Main navigation label 'payment settings'"
+                defaultMessage="Payment"
+              />
+            </NavItem>,
+            <NavItem
+              key="data-removal"
+              to={generatePath('/forms/:formId/settings/data-removal', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_DATA_REMOVAL)}
+            >
+              <Outline.ArchiveBoxIcon />
+              <FormattedMessage
+                description="Main navigation label 'data removal settings'"
+                defaultMessage="Data removal"
+              />
+            </NavItem>,
+            <NavItem
+              key="translations"
+              to={generatePath('/forms/:formId/settings/translations', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_TRANSLATIONS)}
+            >
+              <Outline.LanguageIcon />
+              <FormattedMessage
+                description="Main navigation label 'translations settings'"
+                defaultMessage="Translations"
+              />
+            </NavItem>,
+            <NavItem
+              key="history"
+              to={generatePath('/forms/:formId/settings/history', {formId: formId})}
+              isActive={matches.some(m => m.id === PageId.FORM_DETAIL_SETTINGS_HISTORY)}
+            >
+              <Outline.BookOpenIcon />
+              <FormattedMessage
+                description="Main navigation label 'history settings'"
+                defaultMessage="History"
+              />
+            </NavItem>,
+          ]}
+        >
+          <Outline.Cog6ToothIcon />
+          <FormattedMessage
+            description="Main navigation label 'form settings'"
+            defaultMessage="Settings"
+          />
+        </Accordion>,
+      ]}
+    />
+  );
+};
+export default FormDetailMenu;

--- a/src/components/menu/FormDetailMenu/index.ts
+++ b/src/components/menu/FormDetailMenu/index.ts
@@ -1,0 +1,3 @@
+import FormDetailMenu from './FormDetailMenu';
+
+export default FormDetailMenu;

--- a/src/components/menu/MainMenu/MainMenu.stories.tsx
+++ b/src/components/menu/MainMenu/MainMenu.stories.tsx
@@ -1,0 +1,28 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {reactRouterParameters, withRouter} from 'storybook-addon-remix-react-router';
+
+import routes from '@/routes';
+
+import MainMenu from './MainMenu';
+
+export default {
+  title: 'Internal API / Menu / Main Menu',
+  decorators: [withRouter],
+  component: MainMenu,
+  parameters: {
+    controls: {disable: true},
+    reactRouter: reactRouterParameters({
+      location: {
+        path: '/',
+      },
+      routing: {
+        ...routes[0],
+        element: <MainMenu align="space-between" direction="v" />,
+      },
+    }),
+  },
+} satisfies Meta<typeof MainMenu>;
+
+type Story = StoryObj<typeof MainMenu>;
+
+export const Default: Story = {};

--- a/src/components/menu/MainMenu/MainMenu.tsx
+++ b/src/components/menu/MainMenu/MainMenu.tsx
@@ -1,0 +1,72 @@
+import {Accordion, Outline, Toolbar} from '@maykin-ui/admin-ui';
+import {FormattedMessage} from 'react-intl';
+import {generatePath, useMatches} from 'react-router';
+
+import {PageId} from '@/routes/constants';
+
+import NavItem from '../NavItem';
+import type {MenuLevelProps} from '../types';
+
+const MainMenu: React.FC<MenuLevelProps> = ({...toolbarProps}) => {
+  const matches = useMatches();
+
+  return (
+    <Toolbar
+      {...toolbarProps}
+      items={[
+        <Accordion
+          key="form-subject"
+          variant="primary"
+          open
+          toolbarProps={{
+            align: 'space-between',
+          }}
+          items={[
+            <NavItem
+              key="form-categories"
+              to={generatePath('/form-categories')}
+              isActive={matches.some(m => m.id === PageId.FORM_CATEGORIES)}
+              buttonProps={{align: 'space-between'}}
+            >
+              <FormattedMessage
+                description="Main navigation label 'form categories'"
+                defaultMessage="Categories"
+              />
+              <Outline.ArrowRightIcon />
+            </NavItem>,
+            <NavItem
+              key="forms-overview"
+              to={generatePath('/forms')}
+              isActive={matches.some(m => m.id === PageId.FORM_OVERVIEW)}
+              buttonProps={{align: 'space-between'}}
+            >
+              <FormattedMessage
+                description="Main navigation label 'forms overview'"
+                defaultMessage="Forms"
+              />
+              <Outline.ArrowRightIcon />
+            </NavItem>,
+            <NavItem
+              key="form-statistics"
+              to={generatePath('/form-submission-statistics')}
+              isActive={matches.some(m => m.id === PageId.FORM_SUBMISSION_STATISTICS)}
+              buttonProps={{align: 'space-between'}}
+            >
+              <FormattedMessage
+                description="Main navigation label 'form statistics'"
+                defaultMessage="Form statistics"
+              />
+              <Outline.ArrowRightIcon />
+            </NavItem>,
+          ]}
+        >
+          <FormattedMessage
+            description="Main navigation label 'form subject'"
+            defaultMessage="Forms"
+          />
+        </Accordion>,
+      ]}
+    />
+  );
+};
+export default MainMenu;

--- a/src/components/menu/MainMenu/index.ts
+++ b/src/components/menu/MainMenu/index.ts
@@ -1,0 +1,3 @@
+import MainMenu from './MainMenu';
+
+export default MainMenu;

--- a/src/components/menu/NavItem/NavItem.stories.tsx
+++ b/src/components/menu/NavItem/NavItem.stories.tsx
@@ -1,0 +1,27 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {withRouter} from 'storybook-addon-remix-react-router';
+
+import NavItem from './NavItem';
+
+export default {
+  title: 'Internal API / Menu / Nav Item',
+  component: NavItem,
+  decorators: [withRouter],
+} satisfies Meta<typeof NavItem>;
+
+type Story = StoryObj<typeof NavItem>;
+
+export const Default: Story = {
+  args: {
+    children: 'Nav label',
+    to: '/',
+  },
+};
+
+export const Active: Story = {
+  args: {
+    children: 'Nav label',
+    isActive: true,
+    to: '/',
+  },
+};

--- a/src/components/menu/NavItem/NavItem.tsx
+++ b/src/components/menu/NavItem/NavItem.tsx
@@ -1,0 +1,38 @@
+import type {ButtonProps} from '@maykin-ui/admin-ui';
+import {Button} from '@maykin-ui/admin-ui';
+import type {To} from 'react-router';
+import {useNavigate} from 'react-router';
+
+export interface NavItemProps {
+  to: To;
+  isActive?: boolean;
+  buttonProps?: ButtonProps;
+}
+
+const NavItem: React.FC<React.PropsWithChildren<NavItemProps>> = ({
+  to,
+  isActive,
+  children,
+  buttonProps,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <Button
+      key="back-to-forms-overview"
+      {...buttonProps}
+      align={buttonProps?.align || 'start'}
+      // @TODO The active variant should be changed to 'accent'. Needs new admin-ui release
+      variant={buttonProps?.variant || (isActive ? 'secondary' : 'transparent')}
+      onClick={e => {
+        e.preventDefault();
+        navigate(to);
+      }}
+      size={buttonProps?.size || 'xs'}
+    >
+      {children}
+    </Button>
+  );
+};
+
+export default NavItem;

--- a/src/components/menu/NavItem/NavItem.tsx
+++ b/src/components/menu/NavItem/NavItem.tsx
@@ -19,9 +19,9 @@ const NavItem: React.FC<React.PropsWithChildren<NavItemProps>> = ({
 
   return (
     <Button
-      key="back-to-forms-overview"
       {...buttonProps}
       align={buttonProps?.align || 'start'}
+      aria-current={isActive ? 'page' : undefined}
       // @TODO The active variant should be changed to 'accent'. Needs new admin-ui release
       variant={buttonProps?.variant || (isActive ? 'secondary' : 'transparent')}
       onClick={e => {

--- a/src/components/menu/NavItem/index.ts
+++ b/src/components/menu/NavItem/index.ts
@@ -1,0 +1,3 @@
+import NavItem from './NavItem';
+
+export default NavItem;

--- a/src/components/menu/Sidebar.mdx
+++ b/src/components/menu/Sidebar.mdx
@@ -1,0 +1,16 @@
+import {Canvas, Meta} from '@storybook/addon-docs/blocks';
+
+import * as SidebarStories from './Sidebar.stories';
+
+<Meta of={SidebarStories} />
+
+# Sidebar
+
+The `Sidebar` component is used to render the sidebar menu in the Open Formulieren admin-ui. The
+`Sidebar` consists of the application title, a possible subtitle, and main navigation.
+
+Using the React-router `useMatches`, the `Sidebar` determines which menu to render based on the
+current route. Currently, the sidebar only renders the `FormDetailMenu` menu for the form detail
+pages, and `MainMenu` for the top-level pages.
+
+<Canvas of={SidebarStories.MainMenu} />

--- a/src/components/menu/Sidebar.stories.tsx
+++ b/src/components/menu/Sidebar.stories.tsx
@@ -1,0 +1,80 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {reactRouterParameters, withRouter} from 'storybook-addon-remix-react-router';
+
+import {mockFormDetailsGet} from '@/api-mocks';
+import routes from '@/routes';
+
+import Sidebar from './Sidebar';
+
+export default {
+  title: 'Internal API / Menu / Sidebar',
+  component: Sidebar,
+  decorators: [withRouter],
+} satisfies Meta<typeof Sidebar>;
+
+type Story = StoryObj<typeof Sidebar>;
+
+export const MainMenu: Story = {
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: {
+        path: '/',
+      },
+      routing: {
+        ...routes[0],
+        Component: Sidebar,
+      },
+    }),
+  },
+};
+
+export const FormDesignMenu: Story = {
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: {
+        path: '/forms/123/design',
+      },
+      routing: {
+        ...routes[0],
+        Component: Sidebar,
+      },
+    }),
+    msw: {
+      handlers: [mockFormDetailsGet()],
+    },
+  },
+};
+
+export const FormLogicMenu: Story = {
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: {
+        path: '/forms/123/logic',
+      },
+      routing: {
+        ...routes[0],
+        Component: Sidebar,
+      },
+    }),
+    msw: {
+      handlers: [mockFormDetailsGet()],
+    },
+  },
+};
+
+export const FormSettingsMenu: Story = {
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: {
+        path: '/forms/123/settings',
+      },
+      routing: {
+        ...routes[0],
+        Component: Sidebar,
+      },
+    }),
+    msw: {
+      handlers: [mockFormDetailsGet()],
+    },
+  },
+};

--- a/src/components/menu/Sidebar.stories.tsx
+++ b/src/components/menu/Sidebar.stories.tsx
@@ -1,15 +1,17 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
-import {reactRouterParameters, withRouter} from 'storybook-addon-remix-react-router';
+import {reactRouterParameters} from 'storybook-addon-remix-react-router';
+import {expect, userEvent, within} from 'storybook/test';
 
 import {mockFormDetailsGet} from '@/api-mocks';
 import routes from '@/routes';
+import {withMswRouter} from '@/sb-decorators';
 
 import Sidebar from './Sidebar';
 
 export default {
   title: 'Internal API / Menu / Sidebar',
   component: Sidebar,
-  decorators: [withRouter],
+  decorators: [withMswRouter],
 } satisfies Meta<typeof Sidebar>;
 
 type Story = StoryObj<typeof Sidebar>;
@@ -25,6 +27,50 @@ export const MainMenu: Story = {
         Component: Sidebar,
       },
     }),
+  },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+    const subMenu = await canvas.findByRole('region');
+
+    const formNavItems = canvas.getAllByRole('button', {name: 'Forms'});
+
+    // The first 'form' nav item is the menu accordion and is opened
+    expect(formNavItems[0]).toHaveAttribute('aria-expanded', 'true');
+
+    // We need to 'search' the elements actively, as navigation updates the DOM.
+    // Otherwise, the references would become stale.
+    const getCategoriesNavItem = () => canvas.getByRole('button', {name: 'Categories'});
+    const getFormStatsNavItem = () => canvas.getByRole('button', {name: 'Form statistics'});
+
+    await step('Initial state: All nav items are inactive', async () => {
+      const navItems = within(subMenu).getAllByRole('button');
+      expect(navItems).toHaveLength(3);
+      // Validate the contents of the nav items
+      expect(navItems[0]).toHaveTextContent('Categories');
+      expect(navItems[1]).toHaveTextContent('Forms');
+      expect(navItems[2]).toHaveTextContent('Form statistics');
+
+      // All menu items are visible and none are active
+      navItems.forEach(navItem => {
+        expect(navItem).toBeVisible();
+        expect(navItem).not.toHaveAttribute('aria-current');
+      });
+    });
+
+    await step('Select categories nav item', async () => {
+      await userEvent.click(getCategoriesNavItem());
+
+      // The categories nav items should now be active
+      expect(getCategoriesNavItem()).toHaveAttribute('aria-current', 'page');
+    });
+
+    await step('Select form statistics nav item', async () => {
+      await userEvent.click(getFormStatsNavItem());
+
+      // The form stats nav items should now be active, and categories shouldn't anymore
+      expect(getFormStatsNavItem()).toHaveAttribute('aria-current', 'page');
+      expect(getCategoriesNavItem()).not.toHaveAttribute('aria-current');
+    });
   },
 };
 
@@ -43,6 +89,40 @@ export const FormDesignMenu: Story = {
       handlers: [mockFormDetailsGet()],
     },
   },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+    const subMenu = within(await canvas.findByRole('region'));
+
+    const designNavItem = canvas.getByRole('button', {name: 'Design'});
+    const logicNavItem = canvas.getByRole('button', {name: 'Logic'});
+    const settingsNavItem = canvas.getByRole('button', {name: 'Settings'});
+
+    // The design nav item is opened, the others are closed
+    expect(designNavItem).toHaveAttribute('aria-expanded', 'true');
+    expect(logicNavItem).toHaveAttribute('aria-expanded', 'false');
+    expect(settingsNavItem).toHaveAttribute('aria-expanded', 'false');
+
+    await step('All design nav items are inactive', async () => {
+      const navItems = subMenu.getAllByRole('button');
+
+      expect(navItems).toHaveLength(7);
+
+      // Validate the contents of the nav items
+      expect(navItems[0]).toHaveTextContent('Add new step');
+      expect(navItems[1]).toHaveTextContent('Introduction page');
+      expect(navItems[2]).toHaveTextContent('Start page');
+      expect(navItems[3]).toHaveTextContent('Form steps');
+      expect(navItems[4]).toHaveTextContent('Form step 1');
+      expect(navItems[5]).toHaveTextContent('Form step 2');
+      expect(navItems[6]).toHaveTextContent('Confirmation');
+
+      // All menu items are visible and none are active
+      navItems.forEach(navItem => {
+        expect(navItem).toBeVisible();
+        expect(navItem).not.toHaveAttribute('aria-current');
+      });
+    });
+  },
 };
 
 export const FormLogicMenu: Story = {
@@ -60,6 +140,62 @@ export const FormLogicMenu: Story = {
       handlers: [mockFormDetailsGet()],
     },
   },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+    const subMenu = await canvas.findByRole('region');
+
+    const designNavItem = canvas.getByRole('button', {name: 'Design'});
+    const logicNavItem = canvas.getByRole('button', {name: 'Logic'});
+    const settingsNavItem = canvas.getByRole('button', {name: 'Settings'});
+
+    // The logic nav item is opened, the others are closed
+    expect(designNavItem).toHaveAttribute('aria-expanded', 'false');
+    expect(logicNavItem).toHaveAttribute('aria-expanded', 'true');
+    expect(settingsNavItem).toHaveAttribute('aria-expanded', 'false');
+
+    // We need to 'search' the elements actively, as navigation updates the DOM.
+    // Otherwise, the references would become stale.
+    const getFormRulesNavItem = () => canvas.getByRole('button', {name: 'Form rules'});
+    const getAddRuleButton = () => canvas.queryByRole('button', {name: 'Add new logic rule'});
+    const getLibraryRulesNavItem = () => canvas.getByRole('button', {name: 'Library rules'});
+
+    await step('Initial state: all logic nav items are inactive', async () => {
+      const navItems = within(subMenu).getAllByRole('button');
+      expect(navItems).toHaveLength(3);
+      // Validate the contents of the nav items
+      expect(navItems[0]).toHaveTextContent('Form rules');
+      expect(navItems[1]).toHaveTextContent('Library rules');
+      expect(navItems[2]).toHaveTextContent('User variables');
+
+      // All menu items are visible and none are active
+      navItems.forEach(navItem => {
+        expect(navItem).toBeVisible();
+        expect(navItem).not.toHaveAttribute('aria-current');
+      });
+
+      // The "add new logic rule" button should be hidden
+      expect(getAddRuleButton()).not.toBeInTheDocument();
+    });
+
+    await step('Select form rules nav item', async () => {
+      await userEvent.click(getFormRulesNavItem());
+
+      // The form rules nav items should now be active, and the 'add new logic rule'
+      // button should be shown.
+      expect(getFormRulesNavItem()).toHaveAttribute('aria-current', 'page');
+      expect(getAddRuleButton()).toBeVisible();
+    });
+
+    await step('Select library rules nav item', async () => {
+      await userEvent.click(getLibraryRulesNavItem());
+
+      // The library rules nav items should now be active, and form rules shouldn't
+      expect(getLibraryRulesNavItem()).toHaveAttribute('aria-current', 'page');
+      expect(getFormRulesNavItem()).not.toHaveAttribute('aria-current');
+      // The 'add new logic rule' button should again be hidden
+      expect(getAddRuleButton()).not.toBeInTheDocument();
+    });
+  },
 };
 
 export const FormSettingsMenu: Story = {
@@ -76,5 +212,47 @@ export const FormSettingsMenu: Story = {
     msw: {
       handlers: [mockFormDetailsGet()],
     },
+  },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+    const subMenu = within(canvas.getByRole('region'));
+
+    const designNavItem = canvas.getByRole('button', {name: 'Design'});
+    const logicNavItem = canvas.getByRole('button', {name: 'Logic'});
+    const settingsNavItem = canvas.getByRole('button', {name: 'Settings'});
+
+    // The settings nav item is opened, the others are closed
+    expect(designNavItem).toHaveAttribute('aria-expanded', 'false');
+    expect(logicNavItem).toHaveAttribute('aria-expanded', 'false');
+    expect(settingsNavItem).toHaveAttribute('aria-expanded', 'true');
+
+    // Expect the search input to be visible
+    expect(subMenu.getByRole('textbox', {name: 'Search in settings'})).toBeVisible();
+
+    await step('All settings nav items are inactive', async () => {
+      const navItems = subMenu.getAllByRole('button');
+      expect(navItems).toHaveLength(13);
+
+      // Validate the contents of the nav items
+      expect(navItems[0]).toHaveTextContent('Information');
+      expect(navItems[1]).toHaveTextContent('Login');
+      expect(navItems[2]).toHaveTextContent('Availability');
+      expect(navItems[3]).toHaveTextContent('Presentation');
+      expect(navItems[4]).toHaveTextContent('Prefill');
+      expect(navItems[5]).toHaveTextContent('Variables');
+      expect(navItems[6]).toHaveTextContent('Registration');
+      expect(navItems[7]).toHaveTextContent('Confirmation');
+      expect(navItems[8]).toHaveTextContent('Submissions');
+      expect(navItems[9]).toHaveTextContent('Payment');
+      expect(navItems[10]).toHaveTextContent('Data removal');
+      expect(navItems[11]).toHaveTextContent('Translations');
+      expect(navItems[12]).toHaveTextContent('History');
+
+      // All menu items are visible and none are active
+      navItems.forEach(navItem => {
+        expect(navItem).toBeVisible();
+        expect(navItem).not.toHaveAttribute('aria-current');
+      });
+    });
   },
 };

--- a/src/components/menu/Sidebar.tsx
+++ b/src/components/menu/Sidebar.tsx
@@ -1,0 +1,43 @@
+import type {ToolbarProps} from '@maykin-ui/admin-ui';
+import {H2, Sidebar as MyknSidebar, Toolbar} from '@maykin-ui/admin-ui';
+import {useMatches} from 'react-router';
+
+import {PageId} from '@/routes/constants';
+
+import FormDetailMenu from './FormDetailMenu';
+import MainMenu from './MainMenu';
+import {FormDetailSubtitle} from './Subtitle';
+
+const SidebarMenu: React.FC<{isFormDetail: boolean} & ToolbarProps> = ({
+  isFormDetail,
+  ...menuProps
+}) => {
+  if (isFormDetail) {
+    return <FormDetailMenu {...menuProps} />;
+  }
+
+  return <MainMenu {...menuProps} />;
+};
+
+const Sidebar: React.FC = () => {
+  const matches = useMatches();
+  const isFormDetail = matches.some(match => match.id === PageId.FORM_DETAIL);
+  const menuProps: ToolbarProps = {
+    align: 'space-between',
+    direction: 'v',
+    variant: 'transparent',
+    pad: true,
+  };
+
+  return (
+    <MyknSidebar expandable={true}>
+      <Toolbar {...menuProps} compact>
+        <H2>Open Formulieren</H2>
+        {isFormDetail && <FormDetailSubtitle />}
+      </Toolbar>
+      <SidebarMenu isFormDetail={isFormDetail} {...menuProps} />
+    </MyknSidebar>
+  );
+};
+
+export default Sidebar;

--- a/src/components/menu/Subtitle/FormDetailSubtitle.tsx
+++ b/src/components/menu/Subtitle/FormDetailSubtitle.tsx
@@ -1,0 +1,6 @@
+import {H3} from '@maykin-ui/admin-ui';
+
+// @TODO get form name from formik state
+const FormDetailSubtitle: React.FC = () => <H3>Naam formulier</H3>;
+
+export default FormDetailSubtitle;

--- a/src/components/menu/Subtitle/index.ts
+++ b/src/components/menu/Subtitle/index.ts
@@ -1,0 +1,3 @@
+import FormDetailSubtitle from './FormDetailSubtitle';
+
+export {FormDetailSubtitle};

--- a/src/components/menu/types.ts
+++ b/src/components/menu/types.ts
@@ -1,0 +1,3 @@
+import type {ToolbarProps} from '@maykin-ui/admin-ui';
+
+export type MenuLevelProps = ToolbarProps;

--- a/src/hooks/useBreadcrumbItems.ts
+++ b/src/hooks/useBreadcrumbItems.ts
@@ -1,5 +1,4 @@
 import type {BreadcrumbItem} from '@maykin-ui/admin-ui';
-import {useIntl} from 'react-intl';
 import type {UIMatch} from 'react-router';
 import {useMatches} from 'react-router';
 
@@ -16,15 +15,13 @@ import type {RouteHandle} from '@/routes/types';
  * @returns An array of breadcrumb items with `label` and `href` properties.
  */
 export const useBreadcrumbItems = (): BreadcrumbItem[] => {
-  const intl = useIntl();
-
   // To add type safety, we need to cast the matches from UIMatch<unknown, unknown>[]
   // to UIMatch<unknown, RouteHandle>[].
   const matches = useMatches() as UIMatch<unknown, RouteHandle<unknown>>[];
   return matches
     .filter(m => !!m?.handle?.breadcrumbLabel)
     .map(m => ({
-      label: m.handle.breadcrumbLabel!(intl, m.loaderData),
+      label: m.handle.breadcrumbLabel?.(m.loaderData),
       href: m.pathname,
     }));
 };

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -1,3 +1,5 @@
+import {FormattedMessage} from 'react-intl';
+
 import FormLayout from '@/components/layout/FormLayout';
 import RouterErrorBoundary from '@/errors/RouterErrorBoundary';
 import {formLoader, queryClient} from '@/queryClient';
@@ -12,38 +14,38 @@ const routes: RouteObject[] = [
     path: '/',
     ErrorBoundary: RouterErrorBoundary,
     handle: {
-      breadcrumbLabel: intl =>
-        intl.formatMessage({
-          description: 'Route breadcrumb label for home',
-          defaultMessage: 'home',
-        }),
+      breadcrumbLabel: () => (
+        <FormattedMessage description="Route breadcrumb label for home" defaultMessage="home" />
+      ),
     },
     children: [
       {
         path: 'form-categories',
         handle: {
-          breadcrumbLabel: intl =>
-            intl.formatMessage({
-              description: 'Route breadcrumb label for form categories',
-              defaultMessage: 'categories',
-            }),
+          breadcrumbLabel: () => (
+            <FormattedMessage
+              description="Route breadcrumb label for form categories"
+              defaultMessage="categories"
+            />
+          ),
         },
       },
       {
         path: 'forms',
         handle: {
-          breadcrumbLabel: intl =>
-            intl.formatMessage({
-              description: 'Route breadcrumb label for forms overview',
-              defaultMessage: 'forms',
-            }),
+          breadcrumbLabel: () => (
+            <FormattedMessage
+              description="Route breadcrumb label for forms overview"
+              defaultMessage="forms"
+            />
+          ),
         },
         children: [
           {
             path: ':formId',
             loader: ({params}) => formLoader(queryClient, params.formId),
             handle: {
-              breadcrumbLabel: (_, loaderData) => loaderData?.name ?? 'unknown form',
+              breadcrumbLabel: loaderData => loaderData?.name ?? 'unknown form',
             } as RouteHandle<Form | undefined>,
             Component: FormLayout,
             children: formRoutes,
@@ -53,11 +55,12 @@ const routes: RouteObject[] = [
       {
         path: 'form-submission-statistics',
         handle: {
-          breadcrumbLabel: intl =>
-            intl.formatMessage({
-              description: 'Route breadcrumb label for form submission statistics',
-              defaultMessage: 'form submission statistics',
-            }),
+          breadcrumbLabel: () => (
+            <FormattedMessage
+              description="Route breadcrumb label for form submission statistics"
+              defaultMessage="form submission statistics"
+            />
+          ),
         },
       },
     ],

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -5,12 +5,14 @@ import RouterErrorBoundary from '@/errors/RouterErrorBoundary';
 import {formLoader, queryClient} from '@/queryClient';
 import type {Form} from '@/types/form';
 
+import {PageId} from './constants';
 import formRoutes from './form';
 import type {RouteHandle, RouteObject} from './types';
 
 const routes: RouteObject[] = [
   // All other routes, point back to old admin
   {
+    id: PageId.HOME,
     path: '/',
     ErrorBoundary: RouterErrorBoundary,
     handle: {
@@ -20,6 +22,7 @@ const routes: RouteObject[] = [
     },
     children: [
       {
+        id: PageId.FORM_CATEGORIES,
         path: 'form-categories',
         handle: {
           breadcrumbLabel: () => (
@@ -31,6 +34,7 @@ const routes: RouteObject[] = [
         },
       },
       {
+        id: PageId.FORM_OVERVIEW,
         path: 'forms',
         handle: {
           breadcrumbLabel: () => (
@@ -42,6 +46,7 @@ const routes: RouteObject[] = [
         },
         children: [
           {
+            id: PageId.FORM_DETAIL,
             path: ':formId',
             loader: ({params}) => formLoader(queryClient, params.formId),
             handle: {
@@ -53,6 +58,7 @@ const routes: RouteObject[] = [
         ],
       },
       {
+        id: PageId.FORM_SUBMISSION_STATISTICS,
         path: 'form-submission-statistics',
         handle: {
           breadcrumbLabel: () => (

--- a/src/routes/constants.ts
+++ b/src/routes/constants.ts
@@ -1,0 +1,34 @@
+export const PageId = {
+  HOME: 'home',
+  FORM_CATEGORIES: 'form-categories',
+  FORM_OVERVIEW: 'form-overview',
+  FORM_SUBMISSION_STATISTICS: 'form-submission-statistics',
+
+  // Form detail pages
+  FORM_DETAIL: 'form-detail',
+  FORM_DETAIL_DESIGN: 'form-design',
+  FORM_DETAIL_DESIGN_INTRODUCTION: 'form-design-introduction',
+  FORM_DETAIL_DESIGN_START: 'form-design-start',
+  FORM_DETAIL_DESIGN_FORM_STEPS: 'form-design-form-steps',
+  FORM_DETAIL_DESIGN_CONFIRMATION: 'form-design-confirmation',
+  FORM_DETAIL_LOGIC: 'form-logic',
+  FORM_DETAIL_LOGIC_FORM_RULES: 'form-logic-form-rules',
+  FORM_DETAIL_LOGIC_LIBRARY: 'form-logic-library',
+  FORM_DETAIL_LOGIC_USER_VARIABLES: 'form-logic-user-variables',
+  FORM_DETAIL_SETTINGS: 'form-settings',
+  FORM_DETAIL_SETTINGS_GENERAL: 'form-settings-general',
+  FORM_DETAIL_SETTINGS_AUTHENTICATION: 'form-settings-authentication',
+  FORM_DETAIL_SETTINGS_AVAILABILITY: 'form-settings-availability',
+  FORM_DETAIL_SETTINGS_PRESENTATION: 'form-settings-presentation',
+  FORM_DETAIL_SETTINGS_PREFILL: 'form-settings-prefill',
+  FORM_DETAIL_SETTINGS_VARIABLES: 'form-settings-variables',
+  FORM_DETAIL_SETTINGS_REGISTRATION: 'form-settings-registration',
+  FORM_DETAIL_SETTINGS_CONFIRMATION: 'form-settings-confirmation',
+  FORM_DETAIL_SETTINGS_SUBMISSIONS: 'form-settings-submissions',
+  FORM_DETAIL_SETTINGS_PAYMENT: 'form-settings-payment',
+  FORM_DETAIL_SETTINGS_DATA_REMOVAL: 'form-settings-data-removal',
+  FORM_DETAIL_SETTINGS_TRANSLATIONS: 'form-settings-translations',
+  FORM_DETAIL_SETTINGS_HISTORY: 'form-settings-history',
+} as const;
+
+export type PageIdValue = (typeof PageId)[keyof typeof PageId];

--- a/src/routes/form.tsx
+++ b/src/routes/form.tsx
@@ -1,14 +1,17 @@
+import {FormattedMessage} from 'react-intl';
+
 import type {RouteObject} from './types';
 
 const routes: RouteObject[] = [
   {
     path: 'design',
     handle: {
-      breadcrumbLabel: intl =>
-        intl.formatMessage({
-          description: 'Route breadcrumb label for form detail design',
-          defaultMessage: 'design',
-        }),
+      breadcrumbLabel: () => (
+        <FormattedMessage
+          description="Route breadcrumb label for form detail design"
+          defaultMessage="design"
+        />
+      ),
     },
     children: [
       {
@@ -28,11 +31,12 @@ const routes: RouteObject[] = [
   {
     path: 'logic',
     handle: {
-      breadcrumbLabel: intl =>
-        intl.formatMessage({
-          description: 'Route breadcrumb label for form detail logic',
-          defaultMessage: 'logic',
-        }),
+      breadcrumbLabel: () => (
+        <FormattedMessage
+          description="Route breadcrumb label for form detail logic"
+          defaultMessage="logic"
+        />
+      ),
     },
     children: [
       {
@@ -49,11 +53,12 @@ const routes: RouteObject[] = [
   {
     path: 'settings',
     handle: {
-      breadcrumbLabel: intl =>
-        intl.formatMessage({
-          description: 'Route breadcrumb label for form detail settings',
-          defaultMessage: 'settings',
-        }),
+      breadcrumbLabel: () => (
+        <FormattedMessage
+          description="Route breadcrumb label for form detail settings"
+          defaultMessage="settings"
+        />
+      ),
     },
     children: [
       {

--- a/src/routes/form.tsx
+++ b/src/routes/form.tsx
@@ -1,9 +1,11 @@
 import {FormattedMessage} from 'react-intl';
 
+import {PageId} from './constants';
 import type {RouteObject} from './types';
 
 const routes: RouteObject[] = [
   {
+    id: PageId.FORM_DETAIL_DESIGN,
     path: 'design',
     handle: {
       breadcrumbLabel: () => (
@@ -15,20 +17,25 @@ const routes: RouteObject[] = [
     },
     children: [
       {
+        id: PageId.FORM_DETAIL_DESIGN_INTRODUCTION,
         path: 'introduction-page',
       },
       {
+        id: PageId.FORM_DETAIL_DESIGN_START,
         path: 'start-page',
       },
       {
+        id: PageId.FORM_DETAIL_DESIGN_FORM_STEPS,
         path: 'form-steps',
       },
       {
+        id: PageId.FORM_DETAIL_DESIGN_CONFIRMATION,
         path: 'confirmation',
       },
     ],
   },
   {
+    id: PageId.FORM_DETAIL_LOGIC,
     path: 'logic',
     handle: {
       breadcrumbLabel: () => (
@@ -40,17 +47,21 @@ const routes: RouteObject[] = [
     },
     children: [
       {
+        id: PageId.FORM_DETAIL_LOGIC_FORM_RULES,
         path: 'form-rules',
       },
       {
+        id: PageId.FORM_DETAIL_LOGIC_LIBRARY,
         path: 'library',
       },
       {
+        id: PageId.FORM_DETAIL_LOGIC_USER_VARIABLES,
         path: 'user-variables',
       },
     ],
   },
   {
+    id: PageId.FORM_DETAIL_SETTINGS,
     path: 'settings',
     handle: {
       breadcrumbLabel: () => (
@@ -62,42 +73,55 @@ const routes: RouteObject[] = [
     },
     children: [
       {
+        id: PageId.FORM_DETAIL_SETTINGS_GENERAL,
         path: 'general',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_AUTHENTICATION,
         path: 'authentication',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_AVAILABILITY,
         path: 'availability',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_PRESENTATION,
         path: 'presentation',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_PREFILL,
         path: 'prefill',
       },
       {
-        path: 'user-variables',
+        id: PageId.FORM_DETAIL_SETTINGS_VARIABLES,
+        path: 'variables',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_REGISTRATION,
         path: 'registration',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_CONFIRMATION,
         path: 'confirmation',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_SUBMISSIONS,
         path: 'submissions',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_PAYMENT,
         path: 'payment',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_DATA_REMOVAL,
         path: 'data-removal',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_TRANSLATIONS,
         path: 'translations',
       },
       {
+        id: PageId.FORM_DETAIL_SETTINGS_HISTORY,
         path: 'history',
       },
     ],

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -1,11 +1,10 @@
-import type {IntlShape} from 'react-intl';
 import type {
   IndexRouteObject as RRIndexRouteObject,
   NonIndexRouteObject as RRNonIndexRouteObject,
 } from 'react-router';
 
 export interface RouteHandle<T> {
-  breadcrumbLabel?: (intl: IntlShape, loaderData: T) => string;
+  breadcrumbLabel?: (loaderData: T) => React.ReactNode;
 }
 
 /**

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -3,6 +3,8 @@ import type {
   NonIndexRouteObject as RRNonIndexRouteObject,
 } from 'react-router';
 
+import type {PageIdValue} from './constants';
+
 export interface RouteHandle<T> {
   breadcrumbLabel?: (loaderData: T) => React.ReactNode;
 }
@@ -15,7 +17,8 @@ export interface RouteHandle<T> {
  * know what our handlers should look like, we can override this type to ensure that the
  * 'handle' property is typed correctly.
  */
-type IndexRouteObject = Omit<RRIndexRouteObject, 'handle'> & {
+type IndexRouteObject = Omit<RRIndexRouteObject, 'id' | 'handle'> & {
+  id?: PageIdValue;
   handle?: RouteHandle<unknown>;
 };
 
@@ -33,7 +36,8 @@ type IndexRouteObject = Omit<RRIndexRouteObject, 'handle'> & {
  * By overriding this type, we can ensure that the 'handle' property is typed correctly
  * for all routes.
  */
-type NonIndexRouteObject = Omit<RRNonIndexRouteObject, 'handle' | 'children'> & {
+type NonIndexRouteObject = Omit<RRNonIndexRouteObject, 'id' | 'handle' | 'children'> & {
+  id?: PageIdValue;
   handle?: RouteHandle<unknown>;
   children?: RouteObject[];
 };

--- a/vitest.setup.storybook.ts
+++ b/vitest.setup.storybook.ts
@@ -1,6 +1,8 @@
 import {setProjectAnnotations} from '@storybook/react-vite';
 import * as reactIntlAnnotations from 'storybook-react-intl/preview';
-import {beforeAll} from 'vitest';
+import {afterEach, beforeAll} from 'vitest';
+
+import {mswWorker} from '@/api-mocks';
 
 import * as projectAnnotations from './.storybook/preview';
 
@@ -11,3 +13,4 @@ const annotations = setProjectAnnotations([reactIntlAnnotations, projectAnnotati
 beforeAll(() => {
   annotations.beforeAll();
 });
+afterEach(() => mswWorker.resetHandlers());


### PR DESCRIPTION
Closes #7

Implementing the main navigation for the form detail pages, and the main/top level pages.

Through a centralized Sidebar component, the application title, subtitle and navigation are rendered. Using `useMatches` the Sidebar determines which navigation menu should be rendered for the current route. When the `matches` contain the form-detail route, then the `FormDetailMenu` is used, otherwise it uses the `MainMenu`.

Some parts of the navigation are left as TODO's, like adding new form steps and logic rules. These navigation items will be finalized once the Formik state/context is added.