### PR TITLE
Formik controlled checkbox

### DIFF
--- a/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,49 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+
+import {withFormik} from '@/sb-decorators';
+
+import Checkbox from './Checkbox';
+
+export default {
+  title: 'Internal API / Form / Checkbox',
+  component: Checkbox,
+  decorators: [withFormik],
+  args: {
+    name: 'checkbox',
+    label: 'Checkbox label',
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        checkbox: false,
+      },
+    },
+  },
+} satisfies Meta<typeof Checkbox>;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+  parameters: {
+    formik: {
+      initialValues: {
+        checkbox: true,
+      },
+    },
+  },
+};
+
+export const WithError: Story = {
+  parameters: {
+    formik: {
+      initialErrors: {
+        checkbox: 'Invalid!',
+      },
+      initialTouched: {
+        checkbox: true,
+      },
+    },
+  },
+};

--- a/src/components/form/Checkbox/Checkbox.tsx
+++ b/src/components/form/Checkbox/Checkbox.tsx
@@ -1,0 +1,59 @@
+import {ErrorMessage, Checkbox as MyknCheckbox} from '@maykin-ui/admin-ui';
+import {useField, useFormikContext} from 'formik';
+import {useId} from 'react';
+
+import FormField from '../FormField';
+
+export interface CheckboxProps {
+  /**
+   * The name of the form field/input, used to set/track the field value in the form state.
+   */
+  name: string;
+  /**
+   * The (accessible) label for the field - anything that can be rendered.
+   *
+   * You must always provide a label to ensure the field is accessible to users of
+   * assistive technologies.
+   */
+  label: React.ReactNode;
+  /**
+   * Required fields get additional markup/styling to indicate this validation requirement.
+   */
+  isRequired?: boolean;
+}
+
+const Checkbox: React.FC<CheckboxProps> = ({name, label, isRequired}) => {
+  const {validateField} = useFormikContext();
+
+  // the value should not be passed down to underlying checkbox
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [{value, ...props}, {error = '', touched}] = useField<boolean | undefined>({
+    name,
+    type: 'checkbox',
+  });
+  const id = useId();
+
+  const invalid = touched && !!error;
+  const errorMessageId = invalid ? `${id}-error-message` : undefined;
+
+  return (
+    <FormField>
+      {invalid && <ErrorMessage id={errorMessageId}>{error}</ErrorMessage>}
+      <MyknCheckbox
+        id={id}
+        aria-invalid={invalid}
+        aria-describedby={errorMessageId}
+        required={isRequired}
+        {...props}
+        onBlur={async e => {
+          props.onBlur(e);
+          await validateField(name);
+        }}
+      >
+        {label}
+      </MyknCheckbox>
+    </FormField>
+  );
+};
+
+export default Checkbox;

--- a/src/components/form/Checkbox/index.ts
+++ b/src/components/form/Checkbox/index.ts
@@ -1,0 +1,3 @@
+import Checkbox from './Checkbox';
+
+export {Checkbox};

--- a/src/components/form/Toggle/Toggle.tsx
+++ b/src/components/form/Toggle/Toggle.tsx
@@ -4,7 +4,7 @@ import {useId} from 'react';
 
 import FormField from '../FormField';
 
-export interface CheckboxProps {
+export interface ToggleProps {
   /**
    * The name of the form field/input, used to set/track the field value in the form state.
    */
@@ -26,7 +26,7 @@ export interface CheckboxProps {
   labelOff?: string;
 }
 
-const Toggle: React.FC<CheckboxProps> = ({name, label, isRequired, labelOff}) => {
+const Toggle: React.FC<ToggleProps> = ({name, label, isRequired, labelOff}) => {
   const {validateField} = useFormikContext();
 
   // the value should not be passed down to underlying checkbox


### PR DESCRIPTION
Partly closes #26
Depends on #28

Adding a Formik controlled checkbox component, and some form input helper components (Label and FormField)

The error message and error state isn't finalized yet, so this might change in later iterations