### PR TITLE
Fixing parameter arguments in EnvBadge storybook test

### DIFF
--- a/src/components/badge/EnvironmentBadge.stories.tsx
+++ b/src/components/badge/EnvironmentBadge.stories.tsx
@@ -1,4 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
+import {expect, within} from 'storybook/test';
 
 import EnvironmentBadge from '@/components/badge/EnvironmentBadge';
 
@@ -26,8 +27,15 @@ export const HideEnvironmentBadge: Story = {
   parameters: {
     adminSettings: {
       environmentInfo: {
-        showEnvironmentInfo: false,
+        label: 'Env badge',
+        showBadge: false,
       },
     },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // Making sure the badge isn't shown
+    expect(canvas.queryByText('Env badge')).not.toBeInTheDocument();
   },
 };


### PR DESCRIPTION
Closes #35

Fixing the parameters used in the EnvironmentBadge storybook tests