### PR TITLE
Form field spacing

### DIFF
--- a/src/components/form/FieldDescription.scss
+++ b/src/components/form/FieldDescription.scss
@@ -1,0 +1,5 @@
+.openforms-field-description {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}

--- a/src/components/form/FieldDescription.scss
+++ b/src/components/form/FieldDescription.scss
@@ -1,5 +1,5 @@
 .openforms-field-description {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: calc(var(--sizes-spacing-xs-v, 8px) / 2);
 }

--- a/src/components/form/FieldDescription.tsx
+++ b/src/components/form/FieldDescription.tsx
@@ -1,0 +1,7 @@
+import './FieldDescription.scss';
+
+const FieldDescription: React.FC<React.PropsWithChildren> = ({children}) => {
+  return <div className="openforms-field-description">{children}</div>;
+};
+
+export default FieldDescription;

--- a/src/components/form/Select/Select.tsx
+++ b/src/components/form/Select/Select.tsx
@@ -4,6 +4,7 @@ import {useField, useFormikContext} from 'formik';
 import {useId} from 'react';
 
 import Description from '../Description';
+import FieldDescription from '../FieldDescription';
 import FormField from '../FormField';
 import Label from '../Label';
 
@@ -57,12 +58,15 @@ const Select: React.FC<SelectProps> = ({
 
   return (
     <FormField>
-      <Label id={id} isRequired={isRequired}>
-        {label}
-      </Label>
-      {descriptionId && <Description id={descriptionId}>{description}</Description>}
+      <FieldDescription>
+        <Label id={id} isRequired={isRequired}>
+          {label}
+        </Label>
 
-      {invalid && <ErrorMessage id={errorMessageId}>{error}</ErrorMessage>}
+        {descriptionId && <Description id={descriptionId}>{description}</Description>}
+        {invalid && <ErrorMessage id={errorMessageId}>{error}</ErrorMessage>}
+      </FieldDescription>
+
       <MyknSelect
         value={value}
         {...props}


### PR DESCRIPTION
Partly closes #26

The spacing between field label and the error message should be smaller than the spacing between field label and input element.

Using the FieldDescription wrapper we can provide a smaller gap between describing elements, and keep the slightly larger spacing between the describing elements and the form input. (If you have a better name for this wrapper element do drop a suggestion)

Along https://github.com/maykinmedia/admin-ui/pull/309 this will correctly space the form field elements.

Design that showcases this spacing https://www.figma.com/design/gWXiUgpX9qeYz95LZlERe7/AdminUI-DS?node-id=3775-3174&p=f&m=dev