### PR TITLE
Feature/12 formlayout test setup

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,11 +1,16 @@
 import {Button} from '@maykin-ui/admin-ui';
 import type {Decorator} from '@storybook/react-vite';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {Form, Formik} from 'formik';
+import {RouterProvider, createMemoryRouter} from 'react-router';
 import {fn} from 'storybook/test';
 
-import {BASE_URL} from '@/api-mocks';
+import {BASE_URL, mswWorker} from '@/api-mocks';
+import FormLayout from '@/components/layout/FormLayout';
 import AdminSettingsProvider from '@/context/AdminSettingsProvider';
+import RouterErrorBoundary from '@/errors/RouterErrorBoundary';
 import {sessionExpiresAt} from '@/guard/session/session-expiry';
+import {formLoader} from '@/queryClient';
 
 export const withAdminSettingsProvider: Decorator = (Story, {parameters}) => (
   <AdminSettingsProvider
@@ -75,4 +80,66 @@ export const withSessionExpiry: Decorator = (Story, {parameters}) => {
   });
 
   return <Story />;
+};
+
+/**
+ * Decorator for setting up a form detail page with a router and query client. This makes
+ * it possible to test form detail pages and submission actions.
+ *
+ * This simulates a real form detail page, using the formLoader to fetch form data.
+ *
+ * For isolated Formik testing, like testing a singular form field, use the `withFormik`
+ * decorator.
+ *
+ * To capture form submission actions, use the `formDetailPages.onMutate` parameter.
+ */
+export const withFormLayout: Decorator = (Story, {parameters}) => {
+  const storyHandlers = parameters?.msw?.handlers ?? [];
+  const onMutate = parameters?.formDetailPages?.onMutate ?? fn();
+
+  // Register story handlers BEFORE router is created
+  if (storyHandlers.length > 0) {
+    mswWorker.use(...storyHandlers);
+  }
+
+  const storybookQueryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        // Capture mutate calls so we can see submission actions
+        onMutate: variables => onMutate(variables),
+      },
+      queries: {retry: false},
+    },
+  });
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/admin-ui',
+        ErrorBoundary: RouterErrorBoundary,
+        children: [
+          {
+            path: 'forms/:formId',
+            loader: ({params}) => formLoader(storybookQueryClient, params.formId),
+            Component: FormLayout,
+            children: [
+              {
+                index: true,
+                Component: Story,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    {
+      initialEntries: [`/admin-ui/forms/e450890a-4166-410e-8d64-0a54ad30ba01`],
+    }
+  );
+
+  return (
+    <QueryClientProvider client={storybookQueryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
 };

--- a/i18n/compiled/en.json
+++ b/i18n/compiled/en.json
@@ -5,6 +5,12 @@
       "value": "Categories"
     }
   ],
+  "2wkqV6": [
+    {
+      "type": 0,
+      "value": "Preview"
+    }
+  ],
   "6UFbVC": [
     {
       "type": 0,
@@ -89,6 +95,12 @@
     {
       "type": 0,
       "value": "Forms"
+    }
+  ],
+  "RT8KNi": [
+    {
+      "type": 0,
+      "value": "Save"
     }
   ],
   "ZiDANM": [

--- a/i18n/compiled/nl.json
+++ b/i18n/compiled/nl.json
@@ -5,6 +5,12 @@
       "value": "Categorieën"
     }
   ],
+  "2wkqV6": [
+    {
+      "type": 0,
+      "value": "Preview"
+    }
+  ],
   "6UFbVC": [
     {
       "type": 0,
@@ -89,6 +95,12 @@
     {
       "type": 0,
       "value": "Formulieren"
+    }
+  ],
+  "RT8KNi": [
+    {
+      "type": 0,
+      "value": "Opslaan"
     }
   ],
   "ZiDANM": [

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -4,6 +4,11 @@
     "description": "Route breadcrumb label for form categories",
     "originalDefault": "categories"
   },
+  "2wkqV6": {
+    "defaultMessage": "Preview",
+    "description": "Preview button text",
+    "originalDefault": "Preview"
+  },
   "6UFbVC": {
     "defaultMessage": "There was an authentication problem.",
     "description": "'Not authenticated' error message",
@@ -48,6 +53,11 @@
     "defaultMessage": "Forms",
     "description": "Route breadcrumb label for forms overview",
     "originalDefault": "forms"
+  },
+  "RT8KNi": {
+    "defaultMessage": "Save",
+    "description": "Save button text",
+    "originalDefault": "Save"
   },
   "ZiDANM": {
     "defaultMessage": "Home",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -4,6 +4,12 @@
     "description": "Route breadcrumb label for form categories",
     "originalDefault": "categories"
   },
+  "2wkqV6": {
+    "defaultMessage": "Preview",
+    "description": "Preview button text",
+    "isTranslated": true,
+    "originalDefault": "Preview"
+  },
   "6UFbVC": {
     "defaultMessage": "Je moet ingelogd zijn voor deze actie.",
     "description": "'Not authenticated' error message",
@@ -48,6 +54,11 @@
     "defaultMessage": "Formulieren",
     "description": "Route breadcrumb label for forms overview",
     "originalDefault": "forms"
+  },
+  "RT8KNi": {
+    "defaultMessage": "Opslaan",
+    "description": "Save button text",
+    "originalDefault": "Save"
   },
   "ZiDANM": {
     "defaultMessage": "Home",

--- a/src/components/layout/BasicLayout.mdx
+++ b/src/components/layout/BasicLayout.mdx
@@ -1,0 +1,24 @@
+import {ArgTypes, Canvas, Meta} from '@storybook/addon-docs/blocks';
+
+import * as BasicLayoutStories from './BasicLayout.stories';
+
+<Meta of={BasicLayoutStories} />
+
+# Basic Layout
+
+The `BasicLayout` component is the generic layout component for most (if not all) pages in the
+admin-ui. It provides a header, sidebar navigation, main content, and footer.
+
+`BasicLayout` takes a optional `children` prop, which will be used as the main content of the page.
+When the `children` property is not provided, a React-Router `<Outlet/>` will be used as the main
+content, allowing regular Layout usage.
+
+Because the `BasicLayout` component is used by other Layout components, we cannot assign it as a
+global React-router Layout. Otherwise, the elements of the `BasicLayout` would be rendered multiple
+times (as the global Layout, and in every Layout that uses it).
+
+<Canvas of={BasicLayoutStories.Default} />
+
+## Props
+
+<ArgTypes />

--- a/src/components/layout/BasicLayout.stories.tsx
+++ b/src/components/layout/BasicLayout.stories.tsx
@@ -1,5 +1,7 @@
+import {Toolbar} from '@maykin-ui/admin-ui';
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {reactRouterParameters, withRouter} from 'storybook-addon-remix-react-router';
+import {expect, within} from 'storybook/test';
 
 import BasicLayout from '@/components/layout/BasicLayout';
 import type {RouteHandle} from '@/routes/types';
@@ -95,5 +97,31 @@ export const WithDynamicBreadcrumbs: Story = {
         ],
       },
     }),
+  },
+};
+
+export const WithComponentProperties: Story = {
+  args: {
+    children: <SimplePageContent />,
+    footer: (
+      <Toolbar
+        pad
+        variant="alt"
+        align="start"
+        items={[
+          {
+            variant: 'primary',
+            children: 'Footer action',
+          },
+        ]}
+      />
+    ),
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // Both the children and footer content should be rendered
+    expect(canvas.getByText(/Lorem ipsum dolor sit amet/)).toBeVisible();
+    expect(canvas.getByRole('button', {name: 'Footer action'})).toBeVisible();
   },
 };

--- a/src/components/layout/BasicLayout.tsx
+++ b/src/components/layout/BasicLayout.tsx
@@ -12,7 +12,19 @@ import {Outlet} from 'react-router';
 import {EnvironmentBadge, FormStatusBadge} from '@/components/badge';
 import {useBreadcrumbItems} from '@/hooks/useBreadcrumbItems';
 
-const BasicLayout = () => {
+export interface BasicLayoutProps {
+  /**
+   * The content to be displayed inside the layout. If not provided, the Outlet component
+   * will be used to render the current route's content.
+   */
+  children?: React.ReactNode;
+  /**
+   * The footer content to be displayed at the bottom of the layout.
+   */
+  footer?: React.ReactNode;
+}
+
+const BasicLayout: React.FC<BasicLayoutProps> = ({footer, children}) => {
   const breadcrumbItems = useBreadcrumbItems();
   return (
     <CardBaseTemplate
@@ -81,36 +93,12 @@ const BasicLayout = () => {
           />,
         ]}
       />
-      <Body fullHeight>
-        <Outlet />
-      </Body>
-      <Column direction="row" span={12}>
-        <Toolbar
-          pad
-          variant="alt"
-          align="start"
-          items={[
-            {
-              variant: 'primary',
-              children: (
-                <>
-                  <Outline.BookmarkSquareIcon />
-                  Action 1
-                </>
-              ),
-            },
-            {
-              variant: 'secondary',
-              children: (
-                <>
-                  <Outline.EyeIcon />
-                  Action 2
-                </>
-              ),
-            },
-          ]}
-        />
-      </Column>
+      <Body fullHeight>{children ?? <Outlet />}</Body>
+      {footer && (
+        <Column direction="row" span={12}>
+          {footer}
+        </Column>
+      )}
     </CardBaseTemplate>
   );
 };

--- a/src/components/layout/FormLayout.mdx
+++ b/src/components/layout/FormLayout.mdx
@@ -30,13 +30,14 @@ implementation and testing simple.
 A simple form page example:
 
 ```tsx
-import {Field, Form} from 'formik';
+import {Form} from 'formik';
+
+import {TextField} from '@/components/form/TextField';
 
 const FormPageContent: React.FC = () => {
   return (
     <Form>
-      <label htmlFor="form-name">Form name</label>
-      <Field id="form-name" name="name" />
+      <TextField name="name" label="Form name" />
     </Form>
   );
 };

--- a/src/components/layout/FormLayout.mdx
+++ b/src/components/layout/FormLayout.mdx
@@ -14,7 +14,7 @@ adds Formik state/context for form editing, and handles the form submission. It 
 `formLoader` loader uses a tanstack query client to keep a cached version of the form details, to
 prevent duplicate API requests.
 
-The form submissions are persisted through `useFormMutation`, which implementes a tanstack
+The form submissions are persisted through `useFormMutation`, which implements a tanstack
 useMutation. `useFormMutation` persists the data to API, and updates the local form details cache.
 
 The Formik state/context is added through a secondary `FormLayoutInner` component.

--- a/src/components/layout/FormLayout.mdx
+++ b/src/components/layout/FormLayout.mdx
@@ -6,15 +6,16 @@ import * as FormLayoutStories from './FormLayout.stories';
 
 # Form Layout
 
-The `FormLayout` component is used to provide Formik state/context to the form-detail pages, and
-handle the form submission.
+The `FormLayout` component is a layout component for form-detail pages. The `FormLayout` component
+adds Formik state/context for form editing, and handles the form submission. It also implements the
+`BasicLayout` component, and adds footer controls for saving and previewing the form.
 
-`FormLayout` use the custom react-router loader `formLoader` to fetch the form details. The
+`FormLayout` uses the custom react-router loader `formLoader` to fetch the form details. The
 `formLoader` loader uses a tanstack query client to keep a cached version of the form details, to
 prevent duplicate API requests.
 
-The form submissions are persisted through a tanstack useMutation: `useFormMutation`.
-`useFormMutation` persists the data to API, and updates the local form details cache.
+The form submissions are persisted through `useFormMutation`, which implementes a tanstack
+useMutation. `useFormMutation` persists the data to API, and updates the local form details cache.
 
 The Formik state/context is added through a secondary `FormLayoutInner` component.
 
@@ -29,20 +30,13 @@ implementation and testing simple.
 A simple form page example:
 
 ```tsx
-import {Button} from '@maykin-ui/admin-ui';
 import {Field, Form} from 'formik';
 
 const FormPageContent: React.FC = () => {
   return (
     <Form>
-      <div>
-        <label htmlFor="form-name">Form name</label>
-        <Field id="form-name" name="name" />
-      </div>
-
-      <Button variant="primary" type="submit">
-        Submit
-      </Button>
+      <label htmlFor="form-name">Form name</label>
+      <Field id="form-name" name="name" />
     </Form>
   );
 };

--- a/src/components/layout/FormLayout.stories.tsx
+++ b/src/components/layout/FormLayout.stories.tsx
@@ -1,7 +1,6 @@
-import {Button} from '@maykin-ui/admin-ui';
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {Field, Form} from 'formik';
-import {expect, fn, userEvent, waitFor, within} from 'storybook/test';
+import {expect, fireEvent, fn, userEvent, waitFor, within} from 'storybook/test';
 
 import {buildForm, mockFormDetailsGet, mockFormDetailsPut} from '@/api-mocks/form';
 import {withFormLayout} from '@/sb-decorators';
@@ -10,14 +9,8 @@ import {withFormLayout} from '@/sb-decorators';
 const FormPageContent: React.FC = () => {
   return (
     <Form>
-      <div>
-        <label htmlFor="form-name">Form name</label>
-        <Field id="form-name" name="name" autoComplete="false" />
-      </div>
-
-      <Button variant="primary" type="submit">
-        Submit
-      </Button>
+      <label htmlFor="form-name">Form name</label>
+      <Field id="form-name" name="name" autoComplete="false" />
     </Form>
   );
 };
@@ -53,7 +46,10 @@ export const Default: Story = {
     await userEvent.type(formNameInput, 'My awesome form');
     expect(formNameInput).toHaveValue('My awesome form');
 
-    await userEvent.click(await canvas.findByText('Submit'));
+    // Using fireEvent.click instead of userEvent.click because userEvent.click doesn't
+    // actually fire a click event, which we need to trigger the form submission.
+    await fireEvent.click(canvas.getByRole('button', {name: 'Save'}));
+
     await waitFor(() => {
       expect(parameters.formDetailPages.onMutate).toBeCalled();
 

--- a/src/components/layout/FormLayout.stories.tsx
+++ b/src/components/layout/FormLayout.stories.tsx
@@ -1,16 +1,16 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
-import {Field, Form} from 'formik';
+import {Form} from 'formik';
 import {expect, fireEvent, fn, userEvent, waitFor, within} from 'storybook/test';
 
 import {buildForm, mockFormDetailsGet, mockFormDetailsPut} from '@/api-mocks/form';
+import {TextField} from '@/components/form/TextField';
 import {withFormLayout} from '@/sb-decorators';
 
 // @TODO we should replace the Formik Field component with our own form inputs
 const FormPageContent: React.FC = () => {
   return (
     <Form>
-      <label htmlFor="form-name">Form name</label>
-      <Field id="form-name" name="name" autoComplete="false" />
+      <TextField name="name" label="Form name" />
     </Form>
   );
 };

--- a/src/components/layout/FormLayout.stories.tsx
+++ b/src/components/layout/FormLayout.stories.tsx
@@ -1,54 +1,10 @@
 import {Button} from '@maykin-ui/admin-ui';
-import type {Decorator, Meta, StoryObj} from '@storybook/react-vite';
-import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import type {Meta, StoryObj} from '@storybook/react-vite';
 import {Field, Form} from 'formik';
-import {RouterProvider, createMemoryRouter} from 'react-router';
-import {expect, fn, userEvent, within} from 'storybook/test';
+import {expect, fn, userEvent, waitFor, within} from 'storybook/test';
 
-import {mswWorker} from '@/api-mocks';
 import {buildForm, mockFormDetailsGet, mockFormDetailsPut} from '@/api-mocks/form';
-import FormLayout, {FormLayoutInner} from '@/components/layout/FormLayout';
-import {formLoader} from '@/queryClient';
-
-const withFormQueryClientAndRouterProvider: Decorator = (Story, context) => {
-  const storyHandlers = context.parameters?.msw?.handlers ?? [];
-
-  // Register story handlers BEFORE router is created
-  if (storyHandlers.length > 0) {
-    mswWorker.use(...storyHandlers);
-  }
-
-  const storybookQueryClient = new QueryClient({
-    defaultOptions: {
-      queries: {retry: false},
-    },
-  });
-
-  const router = createMemoryRouter(
-    [
-      {
-        path: '/admin-ui/form/:formId',
-        loader: ({params}) => formLoader(storybookQueryClient, params.formId),
-        Component: FormLayout,
-        children: [
-          {
-            index: true,
-            Component: Story, // Story rendered inside the route
-          },
-        ],
-      },
-    ],
-    {
-      initialEntries: ['/admin-ui/form/e450890a-4166-410e-8d64-0a54ad30ba01'],
-    }
-  );
-
-  return (
-    <QueryClientProvider client={storybookQueryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  );
-};
+import {withFormLayout} from '@/sb-decorators';
 
 // @TODO we should replace the Formik Field component with our own form inputs
 const FormPageContent: React.FC = () => {
@@ -68,22 +24,25 @@ const FormPageContent: React.FC = () => {
 
 export default {
   title: 'Internal API / Layout / Form Layout',
-  component: FormLayout,
-} satisfies Meta<typeof FormLayout>;
-
-type FormLayoutInnerStory = StoryObj<typeof FormLayoutInner>;
-
-export const Default: FormLayoutInnerStory = {
-  render: args => (
-    <FormLayoutInner initialValues={args.initialValues} onSubmit={args.onSubmit}>
-      <FormPageContent />
-    </FormLayoutInner>
-  ),
-  args: {
-    initialValues: buildForm(),
-    onSubmit: fn(),
+  component: FormPageContent,
+  decorators: [withFormLayout],
+  parameters: {
+    layout: 'fullscreen',
+    formDetailPages: {
+      onMutate: fn(),
+    },
   },
-  play: async ({canvasElement, args}) => {
+} satisfies Meta<typeof FormPageContent>;
+
+type Story = StoryObj<typeof FormPageContent>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [mockFormDetailsGet(buildForm()), mockFormDetailsPut()],
+    },
+  },
+  play: async ({canvasElement, parameters}) => {
     const canvas = within(canvasElement);
 
     const formNameInput = await canvas.findByLabelText('Form name');
@@ -95,21 +54,19 @@ export const Default: FormLayoutInnerStory = {
     expect(formNameInput).toHaveValue('My awesome form');
 
     await userEvent.click(await canvas.findByText('Submit'));
-    expect(args.onSubmit).toBeCalled();
+    await waitFor(() => {
+      expect(parameters.formDetailPages.onMutate).toBeCalled();
 
-    const expectedFormDetails = buildForm({name: 'My awesome form'});
-    expect(args.onSubmit).toBeCalledWith(expectedFormDetails);
+      const expectedFormDetails = buildForm({name: 'My awesome form'});
+      expect(parameters.formDetailPages.onMutate).toBeCalledWith(expectedFormDetails);
+    });
   },
 };
 
-type FromRouterStory = StoryObj;
-
-export const FetchingFormDetailsUsingRouteLoader: FromRouterStory = {
-  decorators: [withFormQueryClientAndRouterProvider],
-  render: () => <FormPageContent />,
+export const FetchingFormDetailsUsingRouteLoader: Story = {
   parameters: {
     msw: {
-      handlers: [mockFormDetailsGet(buildForm({name: 'Route fetched form'})), mockFormDetailsPut()],
+      handlers: [mockFormDetailsGet(buildForm({name: 'Route fetched form'}))],
     },
   },
   play: async ({canvasElement}) => {

--- a/src/components/layout/FormLayout.tsx
+++ b/src/components/layout/FormLayout.tsx
@@ -1,8 +1,12 @@
-import {Formik} from 'formik';
+import {Button, Outline, Toolbar} from '@maykin-ui/admin-ui';
+import {Formik, useFormikContext} from 'formik';
+import {FormattedMessage} from 'react-intl';
 import {Outlet, useLoaderData} from 'react-router';
 
 import {queryClient, useFormMutation} from '@/queryClient';
 import type {Form} from '@/types/form';
+
+import BasicLayout from './BasicLayout';
 
 /**
  * React-router layout component for fetching and handling Form details
@@ -21,7 +25,9 @@ const FormLayout = () => {
 
   return (
     <FormLayoutInner initialValues={form} onSubmit={handleSubmit}>
-      <Outlet />
+      <BasicLayout footer={<FormLayoutFooter />}>
+        <Outlet />
+      </BasicLayout>
     </FormLayoutInner>
   );
 };
@@ -53,5 +59,40 @@ export const FormLayoutInner: React.FC<React.PropsWithChildren<FormLayoutInnerPr
     {children}
   </Formik>
 );
+
+const FormLayoutFooter: React.FC = () => {
+  const {submitForm} = useFormikContext();
+
+  const togglePreview = () => {
+    // @TODO
+    alert('Preview not yet implemented');
+  };
+
+  return (
+    <Toolbar
+      pad
+      variant="alt"
+      align="start"
+      items={[
+        <Button
+          key="save-button"
+          variant="primary"
+          type="button"
+          onClick={async e => {
+            e.preventDefault();
+            await submitForm();
+          }}
+        >
+          <Outline.BookmarkSquareIcon />
+          <FormattedMessage description="Save button text" defaultMessage="Save" />
+        </Button>,
+        <Button key="preview-button" variant="secondary" onClick={togglePreview}>
+          <Outline.EyeIcon />
+          <FormattedMessage description="Preview button text" defaultMessage="Preview" />
+        </Button>,
+      ]}
+    />
+  );
+};
 
 export default FormLayout;

--- a/src/queryClient/form.ts
+++ b/src/queryClient/form.ts
@@ -3,6 +3,7 @@ import {useMutation} from '@tanstack/react-query';
 
 import {BASE_URL} from '@/api-mocks';
 import type {Form} from '@/types/form';
+import {apiCall} from '@/utils/fetch';
 
 export const getFormDetailsQueryKey = (formId?: string) => ['formDetails', formId];
 
@@ -13,7 +14,7 @@ export const formLoader = (
   return queryClient.ensureQueryData({
     queryKey: getFormDetailsQueryKey(formId),
     queryFn: async () => {
-      const response = await fetch(`${BASE_URL}form/${formId}`);
+      const response = await apiCall(`${BASE_URL}form/${formId}`);
       if (response.ok) return response.json();
 
       if (response.status === 404) {
@@ -28,7 +29,7 @@ export const formLoader = (
 export const useFormMutation = (queryClient: QueryClient, formId: string) => {
   return useMutation<Form, Error, Form, {previous?: Form}>({
     mutationFn: async newFormDetails => {
-      const response = await fetch(`${BASE_URL}form/${formId}`, {
+      const response = await apiCall(`${BASE_URL}form/${formId}`, {
         method: 'PUT',
         body: JSON.stringify(newFormDetails),
       });


### PR DESCRIPTION
Partly closes #12

Providing a repeatable setup for form detail page testing, and adding form submission functionality to the form layout.

I've added a new storybook decorator named `withFormLayout`. This decorator adds a React-router routing for the main form detail page (`/admin-ui/forms/:formId`), rendering the `Story` as its index child route. The form detail route uses the `FormLayout` component and `formLoader` route loader, providing access to a QueryClient with form details and a Formik context. This decorator should be used for all storybook tests about the form detail pages.

The `BasicLayout` component now allows you to pass optional `children` and `footer` properties. This allows you to modify the content of the BasicLayout creating possibilities for different page layouts (like the different footer actions in the form-detail pages, and the forms overview page).

The `FormLayout` now uses the `BasicLayout` to pass a custom `FormLayoutFooter` footer property, providing a Formik form submission button.