### PR TITLE
Add presentation settings page

### DIFF
--- a/i18n/compiled/en.json
+++ b/i18n/compiled/en.json
@@ -1,4 +1,10 @@
 {
+  "0uBorL": [
+    {
+      "type": 0,
+      "value": "The text that will be displayed in the form step to go to the previous step"
+    }
+  ],
   "2vFy0E": [
     {
       "type": 0,
@@ -9,6 +15,12 @@
     {
       "type": 0,
       "value": "Preview"
+    }
+  ],
+  "4BhLtR": [
+    {
+      "type": 0,
+      "value": "Form button labels"
     }
   ],
   "6UFbVC": [
@@ -73,6 +85,12 @@
       "value": "Form submission statistics"
     }
   ],
+  "FkU1o8": [
+    {
+      "type": 0,
+      "value": "The text that will be displayed at the start of the form to indicate the user can begin to fill in the form"
+    }
+  ],
   "Fm7wN7": [
     {
       "type": 0,
@@ -109,6 +127,12 @@
       "value": "Your session has expired."
     }
   ],
+  "Ny2VNs": [
+    {
+      "type": 0,
+      "value": "The text that will be displayed in the overview page to change a certain step"
+    }
+  ],
   "OhINq5": [
     {
       "type": 0,
@@ -133,16 +157,40 @@
       "value": "Category"
     }
   ],
+  "Ufxo9U": [
+    {
+      "type": 0,
+      "value": "Show step progression next to the form"
+    }
+  ],
+  "UujtUf": [
+    {
+      "type": 0,
+      "value": "The text that will be displayed in the form step to save the current information"
+    }
+  ],
   "WSiYMn": [
     {
       "type": 0,
       "value": "Unique ID"
     }
   ],
+  "WczS7x": [
+    {
+      "type": 0,
+      "value": "The text that will be displayed in the form step to go to the next step"
+    }
+  ],
   "WzjRYh": [
     {
       "type": 0,
       "value": "Internal name"
+    }
+  ],
+  "ZeeBAX": [
+    {
+      "type": 0,
+      "value": "The buttons in the form use global settings. The buttons below are a preview of the buttons that will be used in the form. To change the button labels, click the 'Edit buttons' button below."
     }
   ],
   "ZiDANM": [
@@ -167,6 +215,30 @@
     {
       "type": 0,
       "value": "Active form"
+    }
+  ],
+  "eRPpMl": [
+    {
+      "type": 0,
+      "value": "Theme"
+    }
+  ],
+  "exbKi7": [
+    {
+      "type": 0,
+      "value": "Edit buttons"
+    }
+  ],
+  "k1QXND": [
+    {
+      "type": 0,
+      "value": "Presentation"
+    }
+  ],
+  "k2Tngs": [
+    {
+      "type": 0,
+      "value": "The text that will be displayed in the overview page to confirm the form is filled in correctly"
     }
   ],
   "nxMx4O": [
@@ -199,6 +271,18 @@
       "value": "Inactive form"
     }
   ],
+  "tJ1m3q": [
+    {
+      "type": 0,
+      "value": "The text that will be displayed in the overview page to go to the previous step"
+    }
+  ],
+  "v9B7G6": [
+    {
+      "type": 0,
+      "value": "Show current step number and total amount of steps below the form title"
+    }
+  ],
   "y0QrgV": [
     {
       "type": 0,
@@ -209,6 +293,12 @@
     {
       "type": 0,
       "value": "Form URL"
+    }
+  ],
+  "z2aEGS": [
+    {
+      "type": 0,
+      "value": "Save"
     }
   ],
   "zEFFxg": [

--- a/i18n/compiled/nl.json
+++ b/i18n/compiled/nl.json
@@ -1,4 +1,10 @@
 {
+  "0uBorL": [
+    {
+      "type": 0,
+      "value": "De tekst op de knop die aangeeft om naar de vorige stap terug te gaan"
+    }
+  ],
   "2vFy0E": [
     {
       "type": 0,
@@ -9,6 +15,12 @@
     {
       "type": 0,
       "value": "Preview"
+    }
+  ],
+  "4BhLtR": [
+    {
+      "type": 0,
+      "value": "Knopteksten formulier"
     }
   ],
   "6UFbVC": [
@@ -73,6 +85,12 @@
       "value": "Inzendingstatistieken"
     }
   ],
+  "FkU1o8": [
+    {
+      "type": 0,
+      "value": "De tekst op de knop die aangeeft dat het formulier gestart kan worden"
+    }
+  ],
   "Fm7wN7": [
     {
       "type": 0,
@@ -109,6 +127,12 @@
       "value": "Je sessie is verlopen."
     }
   ],
+  "Ny2VNs": [
+    {
+      "type": 0,
+      "value": "De tekst op de overzichtspagina om gegevens van een stap te wijzigen"
+    }
+  ],
   "OhINq5": [
     {
       "type": 0,
@@ -133,16 +157,40 @@
       "value": "Categorie"
     }
   ],
+  "Ufxo9U": [
+    {
+      "type": 0,
+      "value": "Toon voortgang aan zijkant"
+    }
+  ],
+  "UujtUf": [
+    {
+      "type": 0,
+      "value": "De tekst op de knop die aangeeft om de huidige stap op te slaan"
+    }
+  ],
   "WSiYMn": [
     {
       "type": 0,
       "value": "Uniek ID"
     }
   ],
+  "WczS7x": [
+    {
+      "type": 0,
+      "value": "De tekst op de knop die aangeeft om naar de volgende stap te gaan"
+    }
+  ],
   "WzjRYh": [
     {
       "type": 0,
       "value": "Interne naam"
+    }
+  ],
+  "ZeeBAX": [
+    {
+      "type": 0,
+      "value": "De knoppen in het formulier hebben een algemene instelling, het voorbeeld van de knoppen zie je hieronder. Wil je de tekst op de knoppen voor dit formulier aanpassen, klik dan op de knop ‘Knoppen aanpassen’."
     }
   ],
   "ZiDANM": [
@@ -167,6 +215,30 @@
     {
       "type": 0,
       "value": "Formulier actief"
+    }
+  ],
+  "eRPpMl": [
+    {
+      "type": 0,
+      "value": "Stijl formulier"
+    }
+  ],
+  "exbKi7": [
+    {
+      "type": 0,
+      "value": "Knoppen aanpassen"
+    }
+  ],
+  "k1QXND": [
+    {
+      "type": 0,
+      "value": "Weergave"
+    }
+  ],
+  "k2Tngs": [
+    {
+      "type": 0,
+      "value": "De tekst om ingevulde gegevens te bevestigen op de overzichtspagina"
     }
   ],
   "nxMx4O": [
@@ -199,6 +271,18 @@
       "value": "Formulier niet actief"
     }
   ],
+  "tJ1m3q": [
+    {
+      "type": 0,
+      "value": "De tekst op de overzichtspagina om naar de vorige stap terug te gaan"
+    }
+  ],
+  "v9B7G6": [
+    {
+      "type": 0,
+      "value": "Toon aantal stappen onder titel formulier"
+    }
+  ],
   "y0QrgV": [
     {
       "type": 0,
@@ -209,6 +293,12 @@
     {
       "type": 0,
       "value": "Volledige URL"
+    }
+  ],
+  "z2aEGS": [
+    {
+      "type": 0,
+      "value": "Bevestigen"
     }
   ],
   "zEFFxg": [

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -1,4 +1,9 @@
 {
+  "0uBorL": {
+    "defaultMessage": "The text that will be displayed in the form step to go to the previous step",
+    "description": "LiteralsForm field '_stepLiterals.previous_text' label",
+    "originalDefault": "The text that will be displayed in the form step to go to the previous step"
+  },
   "2vFy0E": {
     "defaultMessage": "Categories",
     "description": "Route breadcrumb label for form categories",
@@ -8,6 +13,11 @@
     "defaultMessage": "Preview",
     "description": "Preview button text",
     "originalDefault": "Preview"
+  },
+  "4BhLtR": {
+    "defaultMessage": "Form button labels",
+    "description": "Edit form button labels modal title",
+    "originalDefault": "Form button labels"
   },
   "6UFbVC": {
     "defaultMessage": "There was an authentication problem.",
@@ -33,6 +43,11 @@
     "defaultMessage": "Form submission statistics",
     "description": "Route breadcrumb label for form submission statistics",
     "originalDefault": "form submission statistics"
+  },
+  "FkU1o8": {
+    "defaultMessage": "The text that will be displayed at the start of the form to indicate the user can begin to fill in the form",
+    "description": "LiteralsForm field 'literals.begin_text' label",
+    "originalDefault": "The text that will be displayed at the start of the form to indicate the user can begin to fill in the form"
   },
   "Fm7wN7": {
     "defaultMessage": "Slug",
@@ -64,6 +79,11 @@
     "description": "Session expiry notice - expired",
     "originalDefault": "Your session has expired."
   },
+  "Ny2VNs": {
+    "defaultMessage": "The text that will be displayed in the overview page to change a certain step",
+    "description": "LiteralsForm field 'literals.change_text' label",
+    "originalDefault": "The text that will be displayed in the overview page to change a certain step"
+  },
   "OhINq5": {
     "defaultMessage": "View general configuration",
     "description": "General configuration button text",
@@ -84,15 +104,35 @@
     "description": "Form detail field 'category' label",
     "originalDefault": "Category"
   },
+  "Ufxo9U": {
+    "defaultMessage": "Show step progression next to the form",
+    "description": "Form detail field 'showProgressIndicator' label",
+    "originalDefault": "Show step progression next to the form"
+  },
+  "UujtUf": {
+    "defaultMessage": "The text that will be displayed in the form step to save the current information",
+    "description": "LiteralsForm field '_stepLiterals.save_text' label",
+    "originalDefault": "The text that will be displayed in the form step to save the current information"
+  },
   "WSiYMn": {
     "defaultMessage": "Unique ID",
     "description": "Form detail field 'uuid' label",
     "originalDefault": "Unique ID"
   },
+  "WczS7x": {
+    "defaultMessage": "The text that will be displayed in the form step to go to the next step",
+    "description": "LiteralsForm field '_stepLiterals.next_text' label",
+    "originalDefault": "The text that will be displayed in the form step to go to the next step"
+  },
   "WzjRYh": {
     "defaultMessage": "Internal name",
     "description": "Form detail field 'internalName' label",
     "originalDefault": "Internal name"
+  },
+  "ZeeBAX": {
+    "defaultMessage": "The buttons in the form use global settings. The buttons below are a preview of the buttons that will be used in the form. To change the button labels, click the 'Edit buttons' button below.",
+    "description": "Form detail presentation settings form buttons preview description",
+    "originalDefault": "The buttons in the form use global settings. The buttons below are a preview of the buttons that will be used in the form. To change the button labels, click the 'Edit buttons' button below."
   },
   "ZiDANM": {
     "defaultMessage": "Home",
@@ -113,6 +153,26 @@
     "defaultMessage": "Active form",
     "description": "Label for form status \"active\"",
     "originalDefault": "Active form"
+  },
+  "eRPpMl": {
+    "defaultMessage": "Theme",
+    "description": "Form detail field 'theme' label",
+    "originalDefault": "Theme"
+  },
+  "exbKi7": {
+    "defaultMessage": "Edit buttons",
+    "description": "Edit form button labels button text",
+    "originalDefault": "Edit buttons"
+  },
+  "k1QXND": {
+    "defaultMessage": "Presentation",
+    "description": "form detail presentation settings page title",
+    "originalDefault": "Presentation"
+  },
+  "k2Tngs": {
+    "defaultMessage": "The text that will be displayed in the overview page to confirm the form is filled in correctly",
+    "description": "LiteralsForm field 'literals.confirm_text' label",
+    "originalDefault": "The text that will be displayed in the overview page to confirm the form is filled in correctly"
   },
   "nxMx4O": {
     "defaultMessage": "Authentication problem",
@@ -139,6 +199,16 @@
     "description": "Label for form status \"inactive\"",
     "originalDefault": "Inactive form"
   },
+  "tJ1m3q": {
+    "defaultMessage": "The text that will be displayed in the overview page to go to the previous step",
+    "description": "LiteralsForm field 'literals.previous_text' label",
+    "originalDefault": "The text that will be displayed in the overview page to go to the previous step"
+  },
+  "v9B7G6": {
+    "defaultMessage": "Show current step number and total amount of steps below the form title",
+    "description": "Form detail field 'showSummaryProgress' label",
+    "originalDefault": "Show current step number and total amount of steps below the form title"
+  },
   "y0QrgV": {
     "defaultMessage": "There settings are only visible for administrators",
     "description": "form detail information settings page 'only for admin' settings",
@@ -148,6 +218,11 @@
     "defaultMessage": "Form URL",
     "description": "Form detail field 'url' label",
     "originalDefault": "Form URL"
+  },
+  "z2aEGS": {
+    "defaultMessage": "Save",
+    "description": "LiteralsForm 'Save' button label",
+    "originalDefault": "Save"
   },
   "zEFFxg": {
     "defaultMessage": "Oops!",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -1,4 +1,9 @@
 {
+  "0uBorL": {
+    "defaultMessage": "De tekst op de knop die aangeeft om naar de vorige stap terug te gaan",
+    "description": "LiteralsForm field '_stepLiterals.previous_text' label",
+    "originalDefault": "The text that will be displayed in the form step to go to the previous step"
+  },
   "2vFy0E": {
     "defaultMessage": "Categorieën",
     "description": "Route breadcrumb label for form categories",
@@ -9,6 +14,11 @@
     "description": "Preview button text",
     "isTranslated": true,
     "originalDefault": "Preview"
+  },
+  "4BhLtR": {
+    "defaultMessage": "Knopteksten formulier",
+    "description": "Edit form button labels modal title",
+    "originalDefault": "Form button labels"
   },
   "6UFbVC": {
     "defaultMessage": "Je moet ingelogd zijn voor deze actie.",
@@ -34,6 +44,11 @@
     "defaultMessage": "Inzendingstatistieken",
     "description": "Route breadcrumb label for form submission statistics",
     "originalDefault": "form submission statistics"
+  },
+  "FkU1o8": {
+    "defaultMessage": "De tekst op de knop die aangeeft dat het formulier gestart kan worden",
+    "description": "LiteralsForm field 'literals.begin_text' label",
+    "originalDefault": "The text that will be displayed at the start of the form to indicate the user can begin to fill in the form"
   },
   "Fm7wN7": {
     "defaultMessage": "URL-deel",
@@ -65,6 +80,11 @@
     "description": "Session expiry notice - expired",
     "originalDefault": "Your session has expired."
   },
+  "Ny2VNs": {
+    "defaultMessage": "De tekst op de overzichtspagina om gegevens van een stap te wijzigen",
+    "description": "LiteralsForm field 'literals.change_text' label",
+    "originalDefault": "The text that will be displayed in the overview page to change a certain step"
+  },
   "OhINq5": {
     "defaultMessage": "Bekijk algemene instellingen",
     "description": "General configuration button text",
@@ -85,15 +105,35 @@
     "description": "Form detail field 'category' label",
     "originalDefault": "Category"
   },
+  "Ufxo9U": {
+    "defaultMessage": "Toon voortgang aan zijkant",
+    "description": "Form detail field 'showProgressIndicator' label",
+    "originalDefault": "Show step progression next to the form"
+  },
+  "UujtUf": {
+    "defaultMessage": "De tekst op de knop die aangeeft om de huidige stap op te slaan",
+    "description": "LiteralsForm field '_stepLiterals.save_text' label",
+    "originalDefault": "The text that will be displayed in the form step to save the current information"
+  },
   "WSiYMn": {
     "defaultMessage": "Uniek ID",
     "description": "Form detail field 'uuid' label",
     "originalDefault": "Unique ID"
   },
+  "WczS7x": {
+    "defaultMessage": "De tekst op de knop die aangeeft om naar de volgende stap te gaan",
+    "description": "LiteralsForm field '_stepLiterals.next_text' label",
+    "originalDefault": "The text that will be displayed in the form step to go to the next step"
+  },
   "WzjRYh": {
     "defaultMessage": "Interne naam",
     "description": "Form detail field 'internalName' label",
     "originalDefault": "Internal name"
+  },
+  "ZeeBAX": {
+    "defaultMessage": "De knoppen in het formulier hebben een algemene instelling, het voorbeeld van de knoppen zie je hieronder. Wil je de tekst op de knoppen voor dit formulier aanpassen, klik dan op de knop ‘Knoppen aanpassen’.",
+    "description": "Form detail presentation settings form buttons preview description",
+    "originalDefault": "The buttons in the form use global settings. The buttons below are a preview of the buttons that will be used in the form. To change the button labels, click the 'Edit buttons' button below."
   },
   "ZiDANM": {
     "defaultMessage": "Home",
@@ -114,6 +154,26 @@
     "defaultMessage": "Formulier actief",
     "description": "Label for form status \"active\"",
     "originalDefault": "Active form"
+  },
+  "eRPpMl": {
+    "defaultMessage": "Stijl formulier",
+    "description": "Form detail field 'theme' label",
+    "originalDefault": "Theme"
+  },
+  "exbKi7": {
+    "defaultMessage": "Knoppen aanpassen",
+    "description": "Edit form button labels button text",
+    "originalDefault": "Edit buttons"
+  },
+  "k1QXND": {
+    "defaultMessage": "Weergave",
+    "description": "form detail presentation settings page title",
+    "originalDefault": "Presentation"
+  },
+  "k2Tngs": {
+    "defaultMessage": "De tekst om ingevulde gegevens te bevestigen op de overzichtspagina",
+    "description": "LiteralsForm field 'literals.confirm_text' label",
+    "originalDefault": "The text that will be displayed in the overview page to confirm the form is filled in correctly"
   },
   "nxMx4O": {
     "defaultMessage": "Inlogprobleem",
@@ -140,6 +200,16 @@
     "description": "Label for form status \"inactive\"",
     "originalDefault": "Inactive form"
   },
+  "tJ1m3q": {
+    "defaultMessage": "De tekst op de overzichtspagina om naar de vorige stap terug te gaan",
+    "description": "LiteralsForm field 'literals.previous_text' label",
+    "originalDefault": "The text that will be displayed in the overview page to go to the previous step"
+  },
+  "v9B7G6": {
+    "defaultMessage": "Toon aantal stappen onder titel formulier",
+    "description": "Form detail field 'showSummaryProgress' label",
+    "originalDefault": "Show current step number and total amount of steps below the form title"
+  },
   "y0QrgV": {
     "defaultMessage": "Onderstaande alleen te zien voor jou",
     "description": "form detail information settings page 'only for admin' settings",
@@ -149,6 +219,11 @@
     "defaultMessage": "Volledige URL",
     "description": "Form detail field 'url' label",
     "originalDefault": "Form URL"
+  },
+  "z2aEGS": {
+    "defaultMessage": "Bevestigen",
+    "description": "LiteralsForm 'Save' button label",
+    "originalDefault": "Save"
   },
   "zEFFxg": {
     "defaultMessage": "Oeps!",

--- a/src/api-mocks/form.ts
+++ b/src/api-mocks/form.ts
@@ -1,6 +1,7 @@
 import type {Mock} from '@vitest/spy';
 import {HttpResponse, http} from 'msw';
 
+import {FORM_STEP_DEFAULTS} from '@/api-mocks/formStep';
 import type {Form} from '@/types/form';
 
 import {BASE_URL_V3, getDefaultFactory} from './base';
@@ -22,13 +23,11 @@ export const FORM_DEFAULTS: Form = {
   confirmationCosignEmailTitle: '',
   confirmationCosignEmailContent: '',
 
-  buttonLiterals: {
-    begin: 'Begin',
-    save: 'Save',
-    next: 'Next',
-    previous: 'Previous',
-    change: 'Change',
-    confirm: 'Confirm',
+  literals: {
+    previous_text: 'Previous page',
+    begin_text: 'Begin form',
+    change_text: 'Change',
+    confirm_text: 'Confirm',
   },
 
   suspensionAllowed: true,
@@ -36,7 +35,7 @@ export const FORM_DEFAULTS: Form = {
   showSummaryProgress: true,
   authenticationBackends: [],
   autoLoginAuthenticationBackend: undefined,
-  steps: [],
+  steps: [FORM_STEP_DEFAULTS],
 
   active: true,
   // Date string in ISO 8601 format

--- a/src/api-mocks/formStep.ts
+++ b/src/api-mocks/formStep.ts
@@ -1,0 +1,26 @@
+import {getDefaultFactory} from '@/api-mocks/base';
+import type {FormStep} from '@/types/form';
+
+export const FORM_STEP_DEFAULTS: FormStep = {
+  uuid: '9251a043-782e-41aa-b57d-e27aa129bb84',
+  slug: 'step-1',
+  index: 0,
+  formDefinition: {},
+  isApplicable: true,
+
+  literals: {
+    next_text: 'Next',
+    previous_text: 'Previous step',
+    save_text: 'Save current information',
+  },
+  translations: {},
+};
+
+/**
+ * Return a form step object as if it would be returned from the form step detail API endpoint.
+ * @param  overrides Key-value mapping with overrides from the defaults. These
+ *                   are deep-assigned via lodash.set to the defaults, so use
+ *                   '.'-joined strings as keys for deep paths.
+ * @return            A form step detail object conforming to the FormStep proptype spec.
+ */
+export const buildFormStep = getDefaultFactory<FormStep>(FORM_STEP_DEFAULTS);

--- a/src/api-mocks/index.ts
+++ b/src/api-mocks/index.ts
@@ -3,6 +3,7 @@ import mswWorker from './msw-worker';
 
 export * from './accounts';
 export * from './category';
+export * from './theme';
 export * from './form';
 
 export {BASE_URL_V2, BASE_URL_V3, mswWorker};

--- a/src/api-mocks/theme.ts
+++ b/src/api-mocks/theme.ts
@@ -1,0 +1,37 @@
+import type {Mock} from '@vitest/spy';
+import {HttpResponse, http} from 'msw';
+
+import {SESSION_EXPIRES_IN_HEADER} from '@/guard/session/session-expiry';
+import type {Theme} from '@/types/theme';
+
+import {BASE_URL_V2} from './base';
+
+const DEFAULT_THEMES: Theme[] = [
+  {
+    name: 'Light theme',
+    uuid: 'f01dc38e-3668-48fa-8963-b6b6e2a9ed6d',
+    url: `${BASE_URL_V2}themes/f01dc38e-3668-48fa-8963-b6b6e2a9ed6d`,
+  },
+  {
+    name: 'Dark theme',
+    uuid: '3f2176b0-adf3-4b6e-a233-93578fac4166',
+    url: `${BASE_URL_V2}themes/3f2176b0-adf3-4b6e-a233-93578fac4166`,
+  },
+];
+
+export const mockThemesGet = (spy?: Mock) =>
+  http.get(
+    `${BASE_URL_V2}themes`,
+    info => {
+      // Call the spy with the request info
+      if (spy) spy(info);
+
+      return HttpResponse.json(DEFAULT_THEMES, {
+        headers: {
+          [SESSION_EXPIRES_IN_HEADER]: `3600`, // Set the session expiry to 1 hour
+        },
+        status: 200,
+      });
+    },
+    {once: false}
+  );

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,0 +1,5 @@
+export * from './Checkbox';
+export * from './RadioField';
+export * from './Select';
+export * from './TextField';
+export * from './Toggle';

--- a/src/components/layout/FormLayout.stories.tsx
+++ b/src/components/layout/FormLayout.stories.tsx
@@ -39,7 +39,10 @@ export const Default: Story = {
     const canvas = within(canvasElement);
 
     const formNameInput = await canvas.findByLabelText('Form name');
-    expect(formNameInput).toHaveValue('Mock form');
+    // Wait for the correct form details to be loaded
+    waitFor(() => {
+      expect(formNameInput).toHaveValue('Mock form');
+    });
 
     // Update the field value
     await userEvent.clear(formNameInput);
@@ -69,6 +72,9 @@ export const FetchingFormDetailsUsingRouteLoader: Story = {
     const canvas = within(canvasElement);
 
     const formNameInput = await canvas.findByLabelText('Form name');
-    expect(formNameInput).toHaveValue('Route fetched form');
+    // Wait for the correct form details to be loaded
+    waitFor(() => {
+      expect(formNameInput).toHaveValue('Route fetched form');
+    });
   },
 };

--- a/src/components/layout/FormLayout.tsx
+++ b/src/components/layout/FormLayout.tsx
@@ -4,7 +4,7 @@ import {FormattedMessage} from 'react-intl';
 import {Outlet, useLoaderData} from 'react-router';
 
 import {queryClient, useFormMutation} from '@/queryClient';
-import type {Form} from '@/types/form';
+import type {InternalForm} from '@/types/form';
 
 import BasicLayout from './BasicLayout';
 
@@ -16,10 +16,10 @@ import BasicLayout from './BasicLayout';
  * separated FormLayoutInner component, to simplify the setup and testing.
  */
 const FormLayout = () => {
-  const form = useLoaderData<Form>();
+  const form = useLoaderData<InternalForm>();
   const {mutate} = useFormMutation(queryClient, form.uuid);
 
-  const handleSubmit = (formDetails: Form) => {
+  const handleSubmit = (formDetails: InternalForm) => {
     mutate(formDetails);
   };
 
@@ -33,8 +33,8 @@ const FormLayout = () => {
 };
 
 export interface FormLayoutInnerProps {
-  initialValues: Form;
-  onSubmit: (formData: Form) => void;
+  initialValues: InternalForm;
+  onSubmit: (formData: InternalForm) => void;
 }
 
 /**
@@ -48,7 +48,7 @@ export const FormLayoutInner: React.FC<React.PropsWithChildren<FormLayoutInnerPr
   onSubmit,
   children,
 }) => (
-  <Formik<Form>
+  <Formik<InternalForm>
     initialValues={initialValues}
     validateOnChange={false}
     validateOnBlur={false}

--- a/src/components/layout/FormLayout.tsx
+++ b/src/components/layout/FormLayout.tsx
@@ -1,9 +1,9 @@
 import {Button, Outline, Toolbar} from '@maykin-ui/admin-ui';
 import {Formik, useFormikContext} from 'formik';
 import {FormattedMessage} from 'react-intl';
-import {Outlet, useLoaderData} from 'react-router';
+import {Outlet, useParams} from 'react-router';
 
-import {queryClient, useFormMutation} from '@/queryClient';
+import {queryClient, useFormMutation, useFormQuery} from '@/queryClient';
 import type {InternalForm} from '@/types/form';
 
 import BasicLayout from './BasicLayout';
@@ -16,12 +16,19 @@ import BasicLayout from './BasicLayout';
  * separated FormLayoutInner component, to simplify the setup and testing.
  */
 const FormLayout = () => {
-  const form = useLoaderData<InternalForm>();
-  const {mutate} = useFormMutation(queryClient, form.uuid);
+  const {formId} = useParams();
+  const form = useFormQuery(queryClient, formId!);
+  const {mutate} = useFormMutation(queryClient, formId!);
 
   const handleSubmit = (formDetails: InternalForm) => {
     mutate(formDetails);
   };
+
+  // Should never happen, as the React-router loader should then trigger a 404.
+  // Included to satisfy TypeScript and catch any potential bugs.
+  if (!form) {
+    return null;
+  }
 
   return (
     <FormLayoutInner initialValues={form} onSubmit={handleSubmit}>
@@ -52,6 +59,7 @@ export const FormLayoutInner: React.FC<React.PropsWithChildren<FormLayoutInnerPr
     initialValues={initialValues}
     validateOnChange={false}
     validateOnBlur={false}
+    enableReinitialize
     onSubmit={async values => {
       await onSubmit(values);
     }}

--- a/src/components/preview/FormButtonsPreview.scss
+++ b/src/components/preview/FormButtonsPreview.scss
@@ -1,0 +1,5 @@
+.openforms-form-buttons-preview {
+  &__toolbar {
+    flex-wrap: wrap;
+  }
+}

--- a/src/components/preview/FormButtonsPreview.tsx
+++ b/src/components/preview/FormButtonsPreview.tsx
@@ -1,0 +1,43 @@
+import {Button, Card, Toolbar} from '@maykin-ui/admin-ui';
+import {clsx} from 'clsx';
+import {useFormikContext} from 'formik';
+
+import type {InternalForm} from '@/types/form';
+
+import './FormButtonsPreview.scss';
+
+export interface FormButtonsPreviewProps {
+  className?: string;
+}
+
+const FormButtonsPreview: React.FC<FormButtonsPreviewProps> = ({className}) => {
+  const {values} = useFormikContext<InternalForm>();
+  const {literals, _stepLiterals} = values;
+
+  // @TODO this should be real preview of the form buttons
+  // i.e. using the formio-renderer buttons and styling from the selected theme
+
+  return (
+    <Card
+      border
+      className={clsx('openforms-form-buttons-preview', className)}
+      data-testid="form-buttons-preview"
+    >
+      <Toolbar pad className="openforms-form-buttons-preview__toolbar">
+        {Object.entries(literals).map(([key, literal]) => (
+          <Button key={`form_${key}`} type="button" variant="primary">
+            {literal}
+          </Button>
+        ))}
+        {_stepLiterals &&
+          Object.entries(_stepLiterals).map(([key, literal]) => (
+            <Button key={`form_step_${key}`} type="button" variant="primary">
+              {literal}
+            </Button>
+          ))}
+      </Toolbar>
+    </Card>
+  );
+};
+
+export default FormButtonsPreview;

--- a/src/pages/form-detail/settings/Presentation/LiteralsForm.tsx
+++ b/src/pages/form-detail/settings/Presentation/LiteralsForm.tsx
@@ -1,0 +1,96 @@
+import {Button} from '@maykin-ui/admin-ui';
+import {Form, Formik} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import {TextField} from '@/components/form';
+import type {InternalForm} from '@/types/form';
+
+export interface LiteralsFormData {
+  literals: InternalForm['literals'];
+  _stepLiterals: InternalForm['_stepLiterals'];
+}
+
+interface LiteralsFormProps {
+  initialValues: LiteralsFormData;
+  onSubmit: (formData: LiteralsFormData) => Promise<void> | void;
+}
+
+const LiteralsForm: React.FC<LiteralsFormProps> = ({initialValues, onSubmit}) => {
+  return (
+    <Formik<LiteralsFormData>
+      initialValues={initialValues}
+      onSubmit={async values => await onSubmit(values)}
+    >
+      <Form data-testid="literals-form">
+        <TextField
+          name="literals.begin_text"
+          label={
+            <FormattedMessage
+              description="LiteralsForm field 'literals.begin_text' label"
+              defaultMessage="The text that will be displayed at the start of the form to indicate the user can begin to fill in the form"
+            />
+          }
+        />
+        <TextField
+          name="literals.previous_text"
+          label={
+            <FormattedMessage
+              description="LiteralsForm field 'literals.previous_text' label"
+              defaultMessage="The text that will be displayed in the overview page to go to the previous step"
+            />
+          }
+        />
+        <TextField
+          name="literals.change_text"
+          label={
+            <FormattedMessage
+              description="LiteralsForm field 'literals.change_text' label"
+              defaultMessage="The text that will be displayed in the overview page to change a certain step"
+            />
+          }
+        />
+        <TextField
+          name="literals.confirm_text"
+          label={
+            <FormattedMessage
+              description="LiteralsForm field 'literals.confirm_text' label"
+              defaultMessage="The text that will be displayed in the overview page to confirm the form is filled in correctly"
+            />
+          }
+        />
+        <TextField
+          name="_stepLiterals.next_text"
+          label={
+            <FormattedMessage
+              description="LiteralsForm field '_stepLiterals.next_text' label"
+              defaultMessage="The text that will be displayed in the form step to go to the next step"
+            />
+          }
+        />
+        <TextField
+          name="_stepLiterals.previous_text"
+          label={
+            <FormattedMessage
+              description="LiteralsForm field '_stepLiterals.previous_text' label"
+              defaultMessage="The text that will be displayed in the form step to go to the previous step"
+            />
+          }
+        />
+        <TextField
+          name="_stepLiterals.save_text"
+          label={
+            <FormattedMessage
+              description="LiteralsForm field '_stepLiterals.save_text' label"
+              defaultMessage="The text that will be displayed in the form step to save the current information"
+            />
+          }
+        />
+        <Button variant="primary" type="submit">
+          <FormattedMessage description="LiteralsForm 'Save' button label" defaultMessage="Save" />
+        </Button>
+      </Form>
+    </Formik>
+  );
+};
+
+export default LiteralsForm;

--- a/src/pages/form-detail/settings/Presentation/Presentation.scss
+++ b/src/pages/form-detail/settings/Presentation/Presentation.scss
@@ -1,0 +1,6 @@
+.openforms-page-presentation {
+  &__form-buttons-preview {
+    margin-block-start: var(--sizes-spacing-s-v, 16px);
+    margin-block-end: var(--sizes-spacing-s-v, 16px);
+  }
+}

--- a/src/pages/form-detail/settings/Presentation/Presentation.stories.tsx
+++ b/src/pages/form-detail/settings/Presentation/Presentation.stories.tsx
@@ -1,0 +1,28 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+
+import {buildForm, mockFormDetailsGet, mockThemesGet} from '@/api-mocks';
+import {withFormLayout} from '@/sb-decorators';
+
+import PresentationPage from './Presentation';
+
+export default {
+  title: 'Pages / Form detail / Settings / Presentation',
+  component: PresentationPage,
+  decorators: [withFormLayout],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof PresentationPage>;
+
+type Story = StoryObj<typeof PresentationPage>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        mockFormDetailsGet(buildForm({theme: 'f01dc38e-3668-48fa-8963-b6b6e2a9ed6d'})),
+        mockThemesGet(),
+      ],
+    },
+  },
+};

--- a/src/pages/form-detail/settings/Presentation/Presentation.stories.tsx
+++ b/src/pages/form-detail/settings/Presentation/Presentation.stories.tsx
@@ -1,6 +1,8 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
+import {expect, fireEvent, fn, userEvent, waitFor, within} from 'storybook/test';
 
-import {buildForm, mockFormDetailsGet, mockThemesGet} from '@/api-mocks';
+import {buildForm, mockFormDetailsGet, mockFormDetailsPut, mockThemesGet} from '@/api-mocks';
+import {buildFormStep} from '@/api-mocks/formStep';
 import {withFormLayout} from '@/sb-decorators';
 
 import PresentationPage from './Presentation';
@@ -24,5 +26,207 @@ export const Default: Story = {
         mockThemesGet(),
       ],
     },
+  },
+};
+
+export const Interaction: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        mockFormDetailsGet(
+          buildForm({
+            theme: '',
+            showProgressIndicator: false,
+            showSummaryProgress: false,
+          })
+        ),
+        // Define the mock form put request with the properties that will be added.
+        // Because we also include the post-PUT scenario in the test, these properties
+        // must reflect the test steps.
+        mockFormDetailsPut(
+          buildForm({
+            theme: 'f01dc38e-3668-48fa-8963-b6b6e2a9ed6d',
+            showProgressIndicator: true,
+            showSummaryProgress: true,
+            literals: {
+              previous_text: 'Go to the previous page',
+              begin_text: 'Start this form',
+              change_text: 'Edit step data',
+              confirm_text: 'Submit form',
+            },
+            steps: [
+              buildFormStep({
+                literals: {
+                  next_text: 'Go to the next step',
+                  previous_text: 'Go to the previous step',
+                  save_text: 'Save step data',
+                },
+              }),
+            ],
+          })
+        ),
+        mockThemesGet(),
+      ],
+    },
+    formDetailPages: {
+      onMutate: fn(),
+    },
+  },
+  play: async ({canvasElement, step, parameters}) => {
+    const canvas = within(canvasElement);
+
+    const formButtonsPreview = within(await canvas.findByTestId('form-buttons-preview'));
+    const theme = await canvas.findByRole('combobox');
+    const nativeSelectForTheme = theme.querySelector<HTMLSelectElement>('select[hidden]')!;
+
+    const showProgressIndicatorField = canvas.getByLabelText(
+      'Show step progression next to the form'
+    );
+    const showSummaryProgressField = canvas.getByLabelText(
+      'Show current step number and total amount of steps below the form title'
+    );
+
+    await step('Initial values', () => {
+      // Initial values of inputs
+      expect(nativeSelectForTheme.value).toBe('');
+      expect(showProgressIndicatorField).not.toBeChecked();
+      expect(showSummaryProgressField).not.toBeChecked();
+
+      // Initial button literals
+      const previewButtons = formButtonsPreview.getAllByRole('button');
+      expect(previewButtons).toHaveLength(7);
+
+      expect(previewButtons[0]).toHaveTextContent('Previous page');
+      expect(previewButtons[1]).toHaveTextContent('Begin form');
+      expect(previewButtons[2]).toHaveTextContent('Change');
+      expect(previewButtons[3]).toHaveTextContent('Confirm');
+      expect(previewButtons[4]).toHaveTextContent('Next');
+      expect(previewButtons[5]).toHaveTextContent('Previous step');
+      expect(previewButtons[6]).toHaveTextContent('Save current information');
+    });
+
+    await step('Entering values', async () => {
+      // Select theme
+      await userEvent.click(theme, {delay: 10});
+      await userEvent.click(await within(theme).findByText('Light theme'), {
+        delay: 10,
+      });
+
+      await userEvent.click(showProgressIndicatorField);
+      await userEvent.click(showSummaryProgressField);
+    });
+
+    await step('Update button literals', async () => {
+      await userEvent.click(canvas.getByRole('button', {name: 'Edit buttons'}));
+
+      // The modal with the literals form is supposed to be shown
+      const literalsForm = await canvas.findByTestId('literals-form');
+      await waitFor(() => {
+        expect(literalsForm).toBeVisible();
+      });
+
+      const literalInputs = within(literalsForm).getAllByRole('textbox');
+      expect(literalInputs).toHaveLength(7);
+
+      // Edit all literals
+      expect(literalInputs[0]).toHaveValue('Begin form');
+      await userEvent.clear(literalInputs[0]);
+      await userEvent.type(literalInputs[0], 'Start this form');
+
+      expect(literalInputs[1]).toHaveValue('Previous page');
+      await userEvent.clear(literalInputs[1]);
+      await userEvent.type(literalInputs[1], 'Go to the previous page');
+
+      expect(literalInputs[2]).toHaveValue('Change');
+      await userEvent.clear(literalInputs[2]);
+      await userEvent.type(literalInputs[2], 'Edit step data');
+
+      expect(literalInputs[3]).toHaveValue('Confirm');
+      await userEvent.clear(literalInputs[3]);
+      await userEvent.type(literalInputs[3], 'Submit form');
+
+      expect(literalInputs[4]).toHaveValue('Next');
+      await userEvent.clear(literalInputs[4]);
+      await userEvent.type(literalInputs[4], 'Go to the next step');
+
+      expect(literalInputs[5]).toHaveValue('Previous step');
+      await userEvent.clear(literalInputs[5]);
+      await userEvent.type(literalInputs[5], 'Go to the previous step');
+
+      expect(literalInputs[6]).toHaveValue('Save current information');
+      await userEvent.clear(literalInputs[6]);
+      await userEvent.type(literalInputs[6], 'Save step data');
+
+      // Submit the literals form
+      await userEvent.click(within(literalsForm).getByRole('button', {name: 'Save'}));
+
+      // The modal with the literals form is no-longer shown
+      await waitFor(() => {
+        expect(literalsForm).not.toBeVisible();
+      });
+    });
+
+    await step('Validating values', async () => {
+      // The category select has the value of the selected category uuid
+      expect(nativeSelectForTheme.value).toBe('f01dc38e-3668-48fa-8963-b6b6e2a9ed6d');
+      expect(showProgressIndicatorField).toBeChecked();
+      expect(showSummaryProgressField).toBeChecked();
+
+      // The button literals should have been updated
+      const previewButtons = formButtonsPreview.getAllByRole('button');
+      expect(previewButtons).toHaveLength(7);
+
+      expect(previewButtons[0]).toHaveTextContent('Go to the previous page');
+      expect(previewButtons[1]).toHaveTextContent('Start this form');
+      expect(previewButtons[2]).toHaveTextContent('Edit step data');
+      expect(previewButtons[3]).toHaveTextContent('Submit form');
+      expect(previewButtons[4]).toHaveTextContent('Go to the next step');
+      expect(previewButtons[5]).toHaveTextContent('Go to the previous step');
+      expect(previewButtons[6]).toHaveTextContent('Save step data');
+    });
+
+    await step('Submit form and validate submitted values', async () => {
+      // Using fireEvent.click instead of userEvent.click because userEvent.click doesn't
+      // actually fire a click event, which we need to trigger the form submission.
+      await fireEvent.click(canvas.getByRole('button', {name: 'Save'}));
+
+      await waitFor(() => {
+        expect(parameters.formDetailPages.onMutate).toBeCalled();
+
+        const expectedFormDetails = buildForm({
+          theme: 'f01dc38e-3668-48fa-8963-b6b6e2a9ed6d',
+          showProgressIndicator: true,
+          showSummaryProgress: true,
+          literals: {
+            previous_text: 'Go to the previous page',
+            begin_text: 'Start this form',
+            change_text: 'Edit step data',
+            confirm_text: 'Submit form',
+          },
+          steps: [
+            buildFormStep({
+              literals: {
+                next_text: 'Go to the next step',
+                previous_text: 'Go to the previous step',
+                save_text: 'Save step data',
+              },
+            }),
+          ],
+        });
+        expect(parameters.formDetailPages.onMutate).toBeCalledWith(expectedFormDetails);
+
+        // Make sure the UI still shows all the preview buttons
+        const previewButtons = formButtonsPreview.getAllByRole('button');
+        expect(previewButtons).toHaveLength(7);
+
+        expect(previewButtons[0]).toHaveTextContent('Go to the previous page');
+        expect(previewButtons[1]).toHaveTextContent('Start this form');
+        expect(previewButtons[2]).toHaveTextContent('Edit step data');
+        expect(previewButtons[3]).toHaveTextContent('Submit form');
+        expect(previewButtons[4]).toHaveTextContent('Go to the next step');
+        expect(previewButtons[5]).toHaveTextContent('Go to the previous step');
+        expect(previewButtons[6]).toHaveTextContent('Save step data');
+      });
+    });
   },
 };

--- a/src/pages/form-detail/settings/Presentation/Presentation.tsx
+++ b/src/pages/form-detail/settings/Presentation/Presentation.tsx
@@ -1,11 +1,14 @@
-import {Column, Grid, H2} from '@maykin-ui/admin-ui';
+import {Column, Grid, H2, P} from '@maykin-ui/admin-ui';
 import {useQuery} from '@tanstack/react-query';
 import {FormattedMessage} from 'react-intl';
 
 import {Checkbox, Select} from '@/components/form';
+import FormButtonsPreview from '@/components/preview/FormButtonsPreview';
 import {useAdminSettings} from '@/hooks/useAdminSettings';
 import type {Theme} from '@/types/theme';
 import {apiCall} from '@/utils/fetch';
+
+import './Presentation.scss';
 
 const PresentationPage: React.FC = () => {
   const {apiBaseUrls} = useAdminSettings();
@@ -58,6 +61,16 @@ const PresentationPage: React.FC = () => {
               />
             }
           />
+
+          <P size="md">
+            <FormattedMessage
+              description="Form detail presentation settings form buttons preview description"
+              defaultMessage={`The buttons in the form use global settings. The buttons
+              below are a preview of the buttons that will be used in the form. To change
+              the button labels, click the 'Edit buttons' button below.`}
+            />
+          </P>
+          <FormButtonsPreview className="openforms-page-presentation__form-buttons-preview" />
         </Column>
       </Grid>
     </div>

--- a/src/pages/form-detail/settings/Presentation/Presentation.tsx
+++ b/src/pages/form-detail/settings/Presentation/Presentation.tsx
@@ -1,0 +1,67 @@
+import {Column, Grid, H2} from '@maykin-ui/admin-ui';
+import {useQuery} from '@tanstack/react-query';
+import {FormattedMessage} from 'react-intl';
+
+import {Checkbox, Select} from '@/components/form';
+import {useAdminSettings} from '@/hooks/useAdminSettings';
+import type {Theme} from '@/types/theme';
+import {apiCall} from '@/utils/fetch';
+
+const PresentationPage: React.FC = () => {
+  const {apiBaseUrls} = useAdminSettings();
+
+  const {data = []} = useQuery<Theme[]>({
+    queryKey: ['form-themes'],
+    queryFn: () => apiCall(`${apiBaseUrls.v2}themes`).then(res => res.json()),
+  });
+
+  const themeOptions = data.map(theme => ({
+    value: theme.uuid,
+    label: theme.name,
+  }));
+
+  return (
+    <div className="openforms-page-presentation">
+      <Grid>
+        <Column span={5} mobileSpan={12}>
+          <H2>
+            <FormattedMessage
+              description="form detail presentation settings page title"
+              defaultMessage="Presentation"
+            />
+          </H2>
+          <Select
+            name="theme"
+            label={
+              <FormattedMessage
+                description="Form detail field 'theme' label"
+                defaultMessage="Theme"
+              />
+            }
+            options={themeOptions}
+          />
+          <Checkbox
+            name="showProgressIndicator"
+            label={
+              <FormattedMessage
+                description="Form detail field 'showProgressIndicator' label"
+                defaultMessage="Show step progression next to the form"
+              />
+            }
+          />
+          <Checkbox
+            name="showSummaryProgress"
+            label={
+              <FormattedMessage
+                description="Form detail field 'showSummaryProgress' label"
+                defaultMessage="Show current step number and total amount of steps below the form title"
+              />
+            }
+          />
+        </Column>
+      </Grid>
+    </div>
+  );
+};
+
+export default PresentationPage;

--- a/src/pages/form-detail/settings/Presentation/Presentation.tsx
+++ b/src/pages/form-detail/settings/Presentation/Presentation.tsx
@@ -1,18 +1,26 @@
-import {Column, Grid, H2, P} from '@maykin-ui/admin-ui';
+import {Body, Button, Column, Grid, H2, H3, Modal, P} from '@maykin-ui/admin-ui';
 import {useQuery} from '@tanstack/react-query';
+import {useFormikContext} from 'formik';
+import {useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {Checkbox, Select} from '@/components/form';
 import FormButtonsPreview from '@/components/preview/FormButtonsPreview';
 import {useAdminSettings} from '@/hooks/useAdminSettings';
+import type {InternalForm} from '@/types/form';
 import type {Theme} from '@/types/theme';
 import {apiCall} from '@/utils/fetch';
 
+import type {LiteralsFormData} from './LiteralsForm';
+import LiteralsForm from './LiteralsForm';
 import './Presentation.scss';
 
 const PresentationPage: React.FC = () => {
+  const {values, setFieldValue} = useFormikContext<InternalForm>();
   const {apiBaseUrls} = useAdminSettings();
+  const {literals, _stepLiterals} = values;
 
+  const [isModalOpen, setModalOpen] = useState(false);
   const {data = []} = useQuery<Theme[]>({
     queryKey: ['form-themes'],
     queryFn: () => apiCall(`${apiBaseUrls.v2}themes`).then(res => res.json()),
@@ -22,6 +30,18 @@ const PresentationPage: React.FC = () => {
     value: theme.uuid,
     label: theme.name,
   }));
+
+  const openModal = () => setModalOpen(true);
+  const closeModal = () => setModalOpen(false);
+
+  const updateLiterals = async (newLiterals: LiteralsFormData) => {
+    // Update formik values with new button labels
+    await setFieldValue('literals', newLiterals.literals);
+    await setFieldValue('_stepLiterals', newLiterals._stepLiterals);
+
+    // Close modal after submission
+    closeModal();
+  };
 
   return (
     <div className="openforms-page-presentation">
@@ -71,8 +91,35 @@ const PresentationPage: React.FC = () => {
             />
           </P>
           <FormButtonsPreview className="openforms-page-presentation__form-buttons-preview" />
+
+          <Button variant="primary" onClick={openModal}>
+            <FormattedMessage
+              description="Edit form button labels button text"
+              defaultMessage="Edit buttons"
+            />
+          </Button>
         </Column>
       </Grid>
+
+      <Modal
+        size="m"
+        position="side"
+        open={isModalOpen}
+        onClose={closeModal}
+        closedby="any"
+        title={
+          <H3>
+            <FormattedMessage
+              description="Edit form button labels modal title"
+              defaultMessage="Form button labels"
+            />
+          </H3>
+        }
+      >
+        <Body>
+          <LiteralsForm initialValues={{literals, _stepLiterals}} onSubmit={updateLiterals} />
+        </Body>
+      </Modal>
     </div>
   );
 };

--- a/src/pages/form-detail/settings/Presentation/index.ts
+++ b/src/pages/form-detail/settings/Presentation/index.ts
@@ -1,0 +1,1 @@
+export {default as PresentationPage} from './Presentation';

--- a/src/pages/form-detail/settings/index.ts
+++ b/src/pages/form-detail/settings/index.ts
@@ -1,3 +1,2 @@
-import {InformationPage} from './Information';
-
-export {InformationPage};
+export {InformationPage} from './Information';
+export {PresentationPage} from './Presentation';

--- a/src/queryClient/form.spec.tsx
+++ b/src/queryClient/form.spec.tsx
@@ -16,8 +16,13 @@ import {
   mswWorker,
 } from '@/api-mocks';
 import AdminSettingsProvider from '@/context/AdminSettingsProvider';
-import {formLoader, getFormDetailsQueryKey, useFormMutation} from '@/queryClient/form';
-import type {Form} from '@/types/form';
+import {
+  formLoader,
+  formToInternalForm,
+  getFormDetailsQueryKey,
+  useFormMutation,
+} from '@/queryClient/form';
+import type {InternalForm} from '@/types/form';
 
 const AppWrapper: React.FC<React.PropsWithChildren> = ({children}) => (
   <AdminSettingsProvider
@@ -43,7 +48,7 @@ const QueryClientProviderWrapper: React.FC<React.PropsWithChildren<{client: Quer
 const PageWithFormMutation: React.FC<{
   testClient: QueryClient;
   formId: string;
-  updatedFormDetails: Form;
+  updatedFormDetails: InternalForm;
 }> = ({testClient, formId, updatedFormDetails}) => {
   const {mutate} = useFormMutation(testClient, formId);
 
@@ -66,7 +71,9 @@ describe('formLoader', () => {
       'e450890a-4166-410e-8d64-0a54ad30ba01'
     );
 
-    await expect(result).toEqual(formDetails);
+    // The form details should be converted to the internal form format
+    const internalForm = formToInternalForm(formDetails);
+    await expect(result).toEqual(internalForm);
   });
 
   it('should throw an 404 error when the api responses with 404', async () => {
@@ -106,7 +113,8 @@ describe('formLoader in router', () => {
 
 describe('useFormMutation', () => {
   it('should update the formDetails cache after successful PUT requests', async () => {
-    const formDetails = buildForm();
+    // The form details inside the queryClient should be of the type InternalForm
+    const internalFormDetails = formToInternalForm(buildForm());
     const updatedFormDetails = buildForm({name: 'Updated form name'});
     mswWorker.use(mockFormDetailsPut(updatedFormDetails));
 
@@ -114,7 +122,7 @@ describe('useFormMutation', () => {
 
     // Set query client data
     const testClient = new QueryClient();
-    testClient.setQueryData(getFormDetailsQueryKey(formId), formDetails);
+    testClient.setQueryData<InternalForm>(getFormDetailsQueryKey(formId), internalFormDetails);
 
     const {getByText} = await render(
       <AppWrapper>
@@ -122,7 +130,7 @@ describe('useFormMutation', () => {
           <PageWithFormMutation
             testClient={testClient}
             formId={formId}
-            updatedFormDetails={updatedFormDetails}
+            updatedFormDetails={formToInternalForm(updatedFormDetails)}
           />
         </QueryClientProviderWrapper>
       </AppWrapper>
@@ -131,20 +139,23 @@ describe('useFormMutation', () => {
 
     // Expect the form data to have been updated
     await waitFor(() =>
-      expect(testClient.getQueryData(getFormDetailsQueryKey(formId))).toEqual(updatedFormDetails)
+      expect(testClient.getQueryData<InternalForm>(getFormDetailsQueryKey(formId))).toEqual(
+        formToInternalForm(updatedFormDetails)
+      )
     );
   });
 
   it('should not update the formDetails cache after failing PUT requests', async () => {
-    const formDetails = buildForm();
-    const updatedFormDetails = buildForm({name: 'Updated form name'});
+    // The form details inside the queryClient should be of the type InternalForm
+    const internalFormDetails = formToInternalForm(buildForm());
+    const internalUpdatedFormDetails = formToInternalForm(buildForm({name: 'Updated form name'}));
     mswWorker.use(mockFormDetailsPutFailure());
 
     const formId = 'e450890a-4166-410e-8d64-0a54ad30ba01';
 
     // Set query client data
     const testClient = new QueryClient();
-    testClient.setQueryData(getFormDetailsQueryKey(formId), formDetails);
+    testClient.setQueryData<InternalForm>(getFormDetailsQueryKey(formId), internalFormDetails);
 
     const {getByText} = await render(
       <AppWrapper>
@@ -152,7 +163,7 @@ describe('useFormMutation', () => {
           <PageWithFormMutation
             testClient={testClient}
             formId={formId}
-            updatedFormDetails={updatedFormDetails}
+            updatedFormDetails={internalUpdatedFormDetails}
           />
         </QueryClientProviderWrapper>
       </AppWrapper>
@@ -161,6 +172,8 @@ describe('useFormMutation', () => {
     await getByText('mutate data').click();
 
     // Expect the form data to not have been updated
-    await expect(testClient.getQueryData(getFormDetailsQueryKey(formId))).toEqual(formDetails);
+    expect(testClient.getQueryData<InternalForm>(getFormDetailsQueryKey(formId))).toEqual(
+      internalFormDetails
+    );
   });
 });

--- a/src/queryClient/form.ts
+++ b/src/queryClient/form.ts
@@ -2,21 +2,63 @@ import type {QueryClient} from '@tanstack/react-query';
 import {useMutation} from '@tanstack/react-query';
 
 import {useAdminSettings} from '@/hooks/useAdminSettings';
-import type {Form} from '@/types/form';
+import type {Form, InternalForm} from '@/types/form';
 import {apiCall} from '@/utils/fetch';
 
 export const getFormDetailsQueryKey = (formId?: string) => ['formDetails', formId];
+
+/**
+ * Transforms a Form object to an InternalForm object.
+ *
+ * The InternalForm type includes properties that are used internally to make editing the
+ * form data easier.
+ */
+export const formToInternalForm = (form: Form): InternalForm => ({
+  ...form,
+  _stepLiterals: form.steps.length
+    ? form.steps[0].literals
+    : {
+        previous_text: '',
+        next_text: '',
+        save_text: '',
+      },
+});
+
+/**
+ * Transforms an InternalForm object to a Form object.
+ *
+ * The InternalForm type includes properties that should only be used internally,
+ * like _stepLiterals. When persisting a form back to the backend, these properties
+ * should not be included.
+ */
+const internalFormToForm = (internalForm: InternalForm): Form => {
+  const stepLiterals = internalForm._stepLiterals;
+
+  // The _stepLiterals data should be copied to the literals of each form step.
+  if (stepLiterals) {
+    internalForm.steps.forEach((_, index) => {
+      internalForm.steps[index].literals = stepLiterals;
+    });
+  }
+
+  // Make sure to delete the _stepLiterals property before returning the form
+  delete internalForm._stepLiterals;
+  return internalForm satisfies Form;
+};
 
 export const formLoader = (
   apiBaseUrl: string,
   queryClient: QueryClient,
   formId?: string
-): Promise<Form | undefined> => {
+): Promise<InternalForm | undefined> => {
   return queryClient.ensureQueryData({
     queryKey: getFormDetailsQueryKey(formId),
     queryFn: async () => {
       const response = await apiCall(`${apiBaseUrl}form/${formId}`);
-      if (response.ok) return response.json();
+      if (response.ok) {
+        const formData: Form = await response.json();
+        return formToInternalForm(formData);
+      }
 
       if (response.status === 404) {
         throw new Response('Form not found', {status: 404, statusText: 'Not found'});
@@ -29,11 +71,14 @@ export const formLoader = (
 
 export const useFormMutation = (queryClient: QueryClient, formId: string) => {
   const {apiBaseUrls} = useAdminSettings();
-  return useMutation<Form, Error, Form, {previous?: Form}>({
+  return useMutation<Form, Error, InternalForm, {previous?: InternalForm}>({
     mutationFn: async newFormDetails => {
+      // The backend expects a Form object, so we need to transform the internal form
+      // back to a Form object.
+      const backendForm = internalFormToForm(newFormDetails);
       const response = await apiCall(`${apiBaseUrls.v3}form/${formId}`, {
         method: 'PUT',
-        body: JSON.stringify(newFormDetails),
+        body: JSON.stringify(backendForm),
       });
 
       if (response.ok) return response.json();
@@ -42,7 +87,12 @@ export const useFormMutation = (queryClient: QueryClient, formId: string) => {
     },
 
     onSuccess: async response => {
-      queryClient.setQueryData(getFormDetailsQueryKey(formId), response);
+      // After a successful PUT update, we need to transform the form back to an
+      // internal form and update the query data in the query client.
+      queryClient.setQueryData<InternalForm>(
+        getFormDetailsQueryKey(formId),
+        formToInternalForm(response)
+      );
     },
   });
 };

--- a/src/queryClient/form.ts
+++ b/src/queryClient/form.ts
@@ -1,5 +1,5 @@
-import type {QueryClient} from '@tanstack/react-query';
-import {useMutation} from '@tanstack/react-query';
+import type {QueryClient, UseBaseQueryOptions} from '@tanstack/react-query';
+import {useMutation, useQuery} from '@tanstack/react-query';
 
 import {useAdminSettings} from '@/hooks/useAdminSettings';
 import type {Form, InternalForm} from '@/types/form';
@@ -46,29 +46,67 @@ const internalFormToForm = (internalForm: InternalForm): Form => {
   return internalForm satisfies Form;
 };
 
-export const formLoader = (
+/**
+ * Default options for fetching form details from queryClient cache, or from the backend.
+ */
+const formQueryOptions = (
+  apiBaseUrl: string,
+  formId?: string
+): UseBaseQueryOptions<InternalForm> => ({
+  queryKey: getFormDetailsQueryKey(formId),
+  queryFn: async () => {
+    const response = await apiCall(`${apiBaseUrl}form/${formId}`);
+    if (response.ok) {
+      const formData: Form = await response.json();
+      return formToInternalForm(formData);
+    }
+
+    if (response.status === 404) {
+      throw new Response('Form not found', {status: 404, statusText: 'Not found'});
+    }
+
+    throw new Error('Failed to fetch form details');
+  },
+});
+
+/**
+ * Custom React-router loader for fetching form details.
+ *
+ * Used to provide preloading on router-level. To fetch the form details, you should NOT
+ * use the React-router useLoaderData hook, instead use the useFormQuery.
+ *
+ * The useLoaderData hook will return the initial data fetched by formLoader, while the
+ * useFormQuery provides access to the updated queryClient cache.
+ */
+export const formLoader = async (
   apiBaseUrl: string,
   queryClient: QueryClient,
   formId?: string
 ): Promise<InternalForm | undefined> => {
-  return queryClient.ensureQueryData({
-    queryKey: getFormDetailsQueryKey(formId),
-    queryFn: async () => {
-      const response = await apiCall(`${apiBaseUrl}form/${formId}`);
-      if (response.ok) {
-        const formData: Form = await response.json();
-        return formToInternalForm(formData);
-      }
-
-      if (response.status === 404) {
-        throw new Response('Form not found', {status: 404, statusText: 'Not found'});
-      }
-
-      throw new Error('Failed to fetch form details');
-    },
-  });
+  return await queryClient.ensureQueryData(formQueryOptions(apiBaseUrl, formId));
 };
 
+/**
+ * Hook to fetch form details from the queryClient cache.
+ */
+export const useFormQuery = (
+  queryClient: QueryClient,
+  formId?: string
+): InternalForm | undefined => {
+  const {apiBaseUrls} = useAdminSettings();
+  const {data} = useQuery(formQueryOptions(apiBaseUrls.v3, formId), queryClient);
+  return data;
+};
+
+/**
+ * Hook to update form details using a queryClient mutation.
+ *
+ * The mutationFn transforms the internal form data back to a server Form object before
+ * performing the PUT request.
+ *
+ * On a successful PUT request, the response is transformed back to an internal form and
+ * updated in the queryClient cache.
+ */
 export const useFormMutation = (queryClient: QueryClient, formId: string) => {
   const {apiBaseUrls} = useAdminSettings();
   return useMutation<Form, Error, InternalForm, {previous?: InternalForm}>({

--- a/src/routes/form.tsx
+++ b/src/routes/form.tsx
@@ -1,4 +1,4 @@
-import {InformationPage} from '@/pages';
+import {InformationPage, PresentationPage} from '@/pages';
 
 import type {RouteObject} from './types';
 
@@ -70,6 +70,7 @@ const routes: RouteObject[] = [
       },
       {
         path: 'presentation',
+        Component: PresentationPage,
       },
       {
         path: 'prefill',

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -154,8 +154,8 @@ export interface Form {
   internalName: string;
   name: string;
   slug: string;
-  category?: string;
-  theme?: number;
+  category?: string; // uuid of category
+  theme?: string; // uuid of theme
   description: string;
 
   introductionPageContent: string;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -13,13 +13,11 @@ export interface FormTranslation {
   confirmationCosignEmailTitle: string;
   confirmationCosignEmailContent: string;
 
-  buttonLiterals: {
-    begin: string;
-    save: string;
-    next: string;
-    previous: string;
-    change: string;
-    confirm: string;
+  literals: {
+    previous_text: string;
+    begin_text: string;
+    change_text: string;
+    confirm_text: string;
   };
 }
 
@@ -130,16 +128,18 @@ export interface FormVariable<T extends FormVariableTypes> {
  * There is a good chance that this interface will change in the future.
  */
 export interface FormStep {
-  id: number;
   uuid: string;
-  name: string;
-  internalName: string;
+  index: number;
   slug: string;
-  order: number;
-  configuration: Record<string, unknown>;
-  loginRequired: boolean;
-  isReusable: boolean;
+  formDefinition: object; // @TODO specify form definition
   isApplicable: boolean;
+
+  literals: {
+    previous_text: string;
+    save_text: string;
+    next_text: string;
+  };
+  translations: object; // @TODO specify translations
 }
 
 /**
@@ -166,13 +166,11 @@ export interface Form {
   confirmationCosignEmailTitle: string;
   confirmationCosignEmailContent: string;
 
-  buttonLiterals: {
-    begin: string;
-    save: string;
-    next: string;
-    previous: string;
-    change: string;
-    confirm: string;
+  literals: {
+    previous_text: string;
+    begin_text: string;
+    change_text: string;
+    confirm_text: string;
   };
 
   suspensionAllowed: boolean;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -224,3 +224,10 @@ export interface Form {
   variables: FormVariable<FormVariableTypes>[];
   translations: FormTranslation[];
 }
+
+export interface InternalForm extends Form {
+  // Frontend-only collection for the step literals. This is used for the step literals
+  // configuration. When submitting the form, these literals are used to update the step
+  // literals. This is done to have a single source of truth for the step literals.
+  _stepLiterals?: FormStep['literals'];
+}

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,0 +1,5 @@
+export type Theme = {
+  url: string;
+  name: string;
+  uuid: string;
+};


### PR DESCRIPTION
Partly closes #12

This PR depends on #51.

Adding the presentation settings page.

The buttons preview will require future changes, to display the actual button styling used in the form and the selected theme. This will be picked up with #47.

The "Go to general settings" button will be included in another PR #49.

The 'Knopteksten formulier' modal isn't exactly like the design describes it. It will require quite some changes to make it closer resemble the look and feel of the design. I've discussed it with Lidwien, and we decided to keep it as is for now.

I've made a PR to the Maykin admin-ui so we can adjust the modal padding a bit better, but still a lot of work is required to make the modal similar to the design.