### PR TITLE
Information page

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -5,7 +5,7 @@ import {Form, Formik} from 'formik';
 import {RouterProvider, createMemoryRouter} from 'react-router';
 import {fn} from 'storybook/test';
 
-import {BASE_URL, mswWorker} from '@/api-mocks';
+import {BASE_URL_V2, BASE_URL_V3, mswWorker} from '@/api-mocks';
 import FormLayout from '@/components/layout/FormLayout';
 import AdminSettingsProvider from '@/context/AdminSettingsProvider';
 import type {AdminSettings} from '@/context/context';
@@ -15,7 +15,7 @@ import {formLoader} from '@/queryClient';
 
 export const withAdminSettingsProvider: Decorator = (Story, {parameters}) => (
   <AdminSettingsProvider
-    apiBaseUrl={parameters?.adminSettings?.apiBaseUrl ?? BASE_URL}
+    apiBaseUrls={parameters?.adminSettings?.apiBaseUrls ?? {v2: BASE_URL_V2, v3: BASE_URL_V3}}
     djangoUrls={
       parameters?.adminSettings?.djangoUrls ??
       ({

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -128,7 +128,7 @@ export const withFormLayout: Decorator = (Story, {parameters}) => {
         children: [
           {
             path: 'forms/:formId',
-            loader: ({params}) => formLoader(storybookQueryClient, params.formId),
+            loader: ({params}) => formLoader(BASE_URL_V3, storybookQueryClient, params.formId),
             Component: FormLayout,
             children: [
               {

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -21,6 +21,7 @@ export const withAdminSettingsProvider: Decorator = (Story, {parameters}) => (
       ({
         generalConfiguration: 'http://localhost:8000/admin/config/globalconfiguration/',
         adminLogin: 'http://localhost:8000/admin/classic-login/',
+        publicRoot: 'http://localhost:8000/',
       } satisfies AdminSettings['djangoUrls'])
     }
     environmentInfo={{

--- a/i18n/compiled/en.json
+++ b/i18n/compiled/en.json
@@ -55,6 +55,12 @@
       "value": "isRequired"
     }
   ],
+  "AuDlLe": [
+    {
+      "type": 0,
+      "value": "Information"
+    }
+  ],
   "BfpzoP": [
     {
       "type": 0,
@@ -67,10 +73,22 @@
       "value": "Form submission statistics"
     }
   ],
+  "Fm7wN7": [
+    {
+      "type": 0,
+      "value": "Slug"
+    }
+  ],
   "JX8BYx": [
     {
       "type": 0,
       "value": "Unfortunately something went wrong!"
+    }
+  ],
+  "K1cg9S": [
+    {
+      "type": 0,
+      "value": "These settings are also visible for citizens"
     }
   ],
   "KJFOCt": [
@@ -109,6 +127,24 @@
       "value": "Save"
     }
   ],
+  "SisPrZ": [
+    {
+      "type": 0,
+      "value": "Category"
+    }
+  ],
+  "WSiYMn": [
+    {
+      "type": 0,
+      "value": "Unique ID"
+    }
+  ],
+  "WzjRYh": [
+    {
+      "type": 0,
+      "value": "Internal name"
+    }
+  ],
   "ZiDANM": [
     {
       "type": 0,
@@ -119,6 +155,12 @@
     {
       "type": 0,
       "value": "Design"
+    }
+  ],
+  "d1gRNB": [
+    {
+      "type": 0,
+      "value": "Suspension allowed"
     }
   ],
   "e/VFua": [
@@ -155,6 +197,18 @@
     {
       "type": 0,
       "value": "Inactive form"
+    }
+  ],
+  "y0QrgV": [
+    {
+      "type": 0,
+      "value": "There settings are only visible for administrators"
+    }
+  ],
+  "y24Z1K": [
+    {
+      "type": 0,
+      "value": "Form URL"
     }
   ],
   "zEFFxg": [

--- a/i18n/compiled/nl.json
+++ b/i18n/compiled/nl.json
@@ -55,6 +55,12 @@
       "value": "isRequired"
     }
   ],
+  "AuDlLe": [
+    {
+      "type": 0,
+      "value": "Informatie"
+    }
+  ],
   "BfpzoP": [
     {
       "type": 0,
@@ -67,10 +73,22 @@
       "value": "Inzendingstatistieken"
     }
   ],
+  "Fm7wN7": [
+    {
+      "type": 0,
+      "value": "URL-deel"
+    }
+  ],
   "JX8BYx": [
     {
       "type": 0,
       "value": "Er ging helaas iets fout!"
+    }
+  ],
+  "K1cg9S": [
+    {
+      "type": 0,
+      "value": "Onderstaande ook te zien voor invuller"
     }
   ],
   "KJFOCt": [
@@ -109,6 +127,24 @@
       "value": "Opslaan"
     }
   ],
+  "SisPrZ": [
+    {
+      "type": 0,
+      "value": "Categorie"
+    }
+  ],
+  "WSiYMn": [
+    {
+      "type": 0,
+      "value": "Uniek ID"
+    }
+  ],
+  "WzjRYh": [
+    {
+      "type": 0,
+      "value": "Interne naam"
+    }
+  ],
   "ZiDANM": [
     {
       "type": 0,
@@ -119,6 +155,12 @@
     {
       "type": 0,
       "value": "Ontwerpen"
+    }
+  ],
+  "d1gRNB": [
+    {
+      "type": 0,
+      "value": "Formulier tussentijds opslaan"
     }
   ],
   "e/VFua": [
@@ -155,6 +197,18 @@
     {
       "type": 0,
       "value": "Formulier niet actief"
+    }
+  ],
+  "y0QrgV": [
+    {
+      "type": 0,
+      "value": "Onderstaande alleen te zien voor jou"
+    }
+  ],
+  "y24Z1K": [
+    {
+      "type": 0,
+      "value": "Volledige URL"
     }
   ],
   "zEFFxg": [

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -19,6 +19,11 @@
     "description": "Form field label content/wrapper",
     "originalDefault": "{isRequired, select, true {{label} <span>Required</span>} other {{label}} }"
   },
+  "AuDlLe": {
+    "defaultMessage": "Information",
+    "description": "form detail information settings page title",
+    "originalDefault": "Information"
+  },
   "BfpzoP": {
     "defaultMessage": "Scheduled form",
     "description": "Label for form status \"scheduled\"",
@@ -29,10 +34,20 @@
     "description": "Route breadcrumb label for form submission statistics",
     "originalDefault": "form submission statistics"
   },
+  "Fm7wN7": {
+    "defaultMessage": "Slug",
+    "description": "Form detail field 'slug' label",
+    "originalDefault": "Slug"
+  },
   "JX8BYx": {
     "defaultMessage": "Unfortunately something went wrong!",
     "description": "'Generic' error message",
     "originalDefault": "Unfortunately something went wrong!"
+  },
+  "K1cg9S": {
+    "defaultMessage": "These settings are also visible for citizens",
+    "description": "form detail information settings page 'also for citizen' settings",
+    "originalDefault": "These settings are also visible for citizens"
   },
   "KJFOCt": {
     "defaultMessage": "Logic",
@@ -64,6 +79,21 @@
     "description": "Save button text",
     "originalDefault": "Save"
   },
+  "SisPrZ": {
+    "defaultMessage": "Category",
+    "description": "Form detail field 'category' label",
+    "originalDefault": "Category"
+  },
+  "WSiYMn": {
+    "defaultMessage": "Unique ID",
+    "description": "Form detail field 'uuid' label",
+    "originalDefault": "Unique ID"
+  },
+  "WzjRYh": {
+    "defaultMessage": "Internal name",
+    "description": "Form detail field 'internalName' label",
+    "originalDefault": "Internal name"
+  },
   "ZiDANM": {
     "defaultMessage": "Home",
     "description": "Route breadcrumb label for home",
@@ -73,6 +103,11 @@
     "defaultMessage": "Design",
     "description": "Route breadcrumb label for form detail design",
     "originalDefault": "design"
+  },
+  "d1gRNB": {
+    "defaultMessage": "Suspension allowed",
+    "description": "Form detail field 'suspensionAllowed' label",
+    "originalDefault": "Suspension allowed"
   },
   "e/VFua": {
     "defaultMessage": "Active form",
@@ -103,6 +138,16 @@
     "defaultMessage": "Inactive form",
     "description": "Label for form status \"inactive\"",
     "originalDefault": "Inactive form"
+  },
+  "y0QrgV": {
+    "defaultMessage": "There settings are only visible for administrators",
+    "description": "form detail information settings page 'only for admin' settings",
+    "originalDefault": "There settings are only visible for administrators"
+  },
+  "y24Z1K": {
+    "defaultMessage": "Form URL",
+    "description": "Form detail field 'url' label",
+    "originalDefault": "Form URL"
   },
   "zEFFxg": {
     "defaultMessage": "Oops!",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -20,6 +20,11 @@
     "description": "Form field label content/wrapper",
     "originalDefault": "{isRequired, select, true {{label} <span>Required</span>} other {{label}} }"
   },
+  "AuDlLe": {
+    "defaultMessage": "Informatie",
+    "description": "form detail information settings page title",
+    "originalDefault": "Information"
+  },
   "BfpzoP": {
     "defaultMessage": "Formulier ingepland",
     "description": "Label for form status \"scheduled\"",
@@ -30,10 +35,20 @@
     "description": "Route breadcrumb label for form submission statistics",
     "originalDefault": "form submission statistics"
   },
+  "Fm7wN7": {
+    "defaultMessage": "URL-deel",
+    "description": "Form detail field 'slug' label",
+    "originalDefault": "Slug"
+  },
   "JX8BYx": {
     "defaultMessage": "Er ging helaas iets fout!",
     "description": "'Generic' error message",
     "originalDefault": "Unfortunately something went wrong!"
+  },
+  "K1cg9S": {
+    "defaultMessage": "Onderstaande ook te zien voor invuller",
+    "description": "form detail information settings page 'also for citizen' settings",
+    "originalDefault": "These settings are also visible for citizens"
   },
   "KJFOCt": {
     "defaultMessage": "Logica",
@@ -65,6 +80,21 @@
     "description": "Save button text",
     "originalDefault": "Save"
   },
+  "SisPrZ": {
+    "defaultMessage": "Categorie",
+    "description": "Form detail field 'category' label",
+    "originalDefault": "Category"
+  },
+  "WSiYMn": {
+    "defaultMessage": "Uniek ID",
+    "description": "Form detail field 'uuid' label",
+    "originalDefault": "Unique ID"
+  },
+  "WzjRYh": {
+    "defaultMessage": "Interne naam",
+    "description": "Form detail field 'internalName' label",
+    "originalDefault": "Internal name"
+  },
   "ZiDANM": {
     "defaultMessage": "Home",
     "description": "Route breadcrumb label for home",
@@ -74,6 +104,11 @@
     "defaultMessage": "Ontwerpen",
     "description": "Route breadcrumb label for form detail design",
     "originalDefault": "design"
+  },
+  "d1gRNB": {
+    "defaultMessage": "Formulier tussentijds opslaan",
+    "description": "Form detail field 'suspensionAllowed' label",
+    "originalDefault": "Suspension allowed"
   },
   "e/VFua": {
     "defaultMessage": "Formulier actief",
@@ -104,6 +139,16 @@
     "defaultMessage": "Formulier niet actief",
     "description": "Label for form status \"inactive\"",
     "originalDefault": "Inactive form"
+  },
+  "y0QrgV": {
+    "defaultMessage": "Onderstaande alleen te zien voor jou",
+    "description": "form detail information settings page 'only for admin' settings",
+    "originalDefault": "There settings are only visible for administrators"
+  },
+  "y24Z1K": {
+    "defaultMessage": "Volledige URL",
+    "description": "Form detail field 'url' label",
+    "originalDefault": "Form URL"
   },
   "zEFFxg": {
     "defaultMessage": "Oeps!",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@maykin-ui/admin-ui": "^3.0.0-alpha.5",
+        "@maykin-ui/admin-ui": "^3.0.0-alpha.6",
         "@tanstack/react-query": "^5.90.16",
         "clsx": "^2.1.1",
         "formik": "^2.4.9",
@@ -1616,9 +1616,9 @@
       }
     },
     "node_modules/@maykin-ui/admin-ui": {
-      "version": "3.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@maykin-ui/admin-ui/-/admin-ui-3.0.0-alpha.5.tgz",
-      "integrity": "sha512-qNConUuJjv2NNRKCbMBhYZTmZzeADFCx4oF7nYt1GHjzOqhP9+4JQ1lc07u7tFgzbsAUCQuV8GID9WckpcscBA==",
+      "version": "3.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@maykin-ui/admin-ui/-/admin-ui-3.0.0-alpha.6.tgz",
+      "integrity": "sha512-YCWN6r/52C1ir09icWAAYUZnVG0+wPSTKEoRxCbvhqGgD0jATvtRmQJmrfjpHQpuFWUEkQRSIGaTo1UjwrPkDQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.5",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "vitest-browser-react": "^2.0.2"
   },
   "dependencies": {
-    "@maykin-ui/admin-ui": "^3.0.0-alpha.5",
+    "@maykin-ui/admin-ui": "^3.0.0-alpha.6",
     "@tanstack/react-query": "^5.90.16",
     "clsx": "^2.1.1",
     "formik": "^2.4.9",

--- a/src/AdminUI.tsx
+++ b/src/AdminUI.tsx
@@ -30,7 +30,7 @@ interface AdminUIProps {
  * Main component to render the Open Forms Admin UI.
  */
 const AdminUI: React.FC<AdminUIProps> = ({environmentInfo, apiBaseUrls, djangoUrls}) => {
-  const router = createBrowserRouter(routes, {
+  const router = createBrowserRouter(routes(apiBaseUrls), {
     basename: '/admin-ui',
   });
 

--- a/src/AdminUI.tsx
+++ b/src/AdminUI.tsx
@@ -14,9 +14,9 @@ interface AdminUIProps {
    */
   environmentInfo: AdminSettings['environmentInfo'];
   /**
-   * Configuration for the Open Forms API base URL.
+   * Configuration for the Open Forms API base URLs.
    */
-  apiBaseUrl: AdminSettings['apiBaseUrl'];
+  apiBaseUrls: AdminSettings['apiBaseUrls'];
   /**
    * The configuration of the Open Forms Django URLs.
    *
@@ -29,7 +29,7 @@ interface AdminUIProps {
 /**
  * Main component to render the Open Forms Admin UI.
  */
-const AdminUI: React.FC<AdminUIProps> = ({environmentInfo, apiBaseUrl, djangoUrls}) => {
+const AdminUI: React.FC<AdminUIProps> = ({environmentInfo, apiBaseUrls, djangoUrls}) => {
   const router = createBrowserRouter(routes, {
     basename: '/admin-ui',
   });
@@ -38,7 +38,7 @@ const AdminUI: React.FC<AdminUIProps> = ({environmentInfo, apiBaseUrl, djangoUrl
     <React.StrictMode>
       <AdminSettingsProvider
         environmentInfo={environmentInfo}
-        apiBaseUrl={apiBaseUrl}
+        apiBaseUrls={apiBaseUrls}
         djangoUrls={djangoUrls}
       >
         <RouterProvider router={router} />

--- a/src/api-mocks/accounts.ts
+++ b/src/api-mocks/accounts.ts
@@ -3,7 +3,7 @@ import {HttpResponse, http} from 'msw';
 
 import {SESSION_EXPIRES_IN_HEADER} from '@/guard/session/session-expiry';
 
-import {BASE_URL} from './base';
+import {BASE_URL_V3} from './base';
 
 /**
  * Mock a request to the api/v3/accounts/me endpoint as an authenticated user, resulting
@@ -15,7 +15,7 @@ import {BASE_URL} from './base';
  */
 export const mockAccountsMeAuthenticatedGet = (mfaVerified: boolean, spy?: Mock) =>
   http.get(
-    `${BASE_URL}accounts/me`,
+    `${BASE_URL_V3}accounts/me`,
     info => {
       // Call the spy with the request info
       if (spy) spy(info);
@@ -42,7 +42,7 @@ export const mockAccountsMeAuthenticatedGet = (mfaVerified: boolean, spy?: Mock)
  */
 export const mockAccountsMeAnonymousGet = (spy?: Mock) =>
   http.get(
-    `${BASE_URL}accounts/me`,
+    `${BASE_URL_V3}accounts/me`,
     info => {
       // Call the spy with the request info
       if (spy) spy(info);

--- a/src/api-mocks/base.ts
+++ b/src/api-mocks/base.ts
@@ -1,6 +1,7 @@
 import {cloneDeep, set} from 'lodash';
 
-export const BASE_URL = 'http://localhost:8000/api/v3/';
+export const BASE_URL_V2 = 'http://localhost:8000/api/v2/';
+export const BASE_URL_V3 = 'http://localhost:8000/api/v3/';
 
 /**
  * Create a function to build an object from a default with optional overrides.

--- a/src/api-mocks/category.ts
+++ b/src/api-mocks/category.ts
@@ -1,0 +1,80 @@
+import type {Mock} from '@vitest/spy';
+import {HttpResponse, http} from 'msw';
+
+import {BASE_URL_V2} from '@/api-mocks/base';
+import {SESSION_EXPIRES_IN_HEADER} from '@/guard/session/session-expiry';
+import type {Category} from '@/types/category';
+
+const DEFAULT_CATEGORIES: Category[] = [
+  {
+    url: `${BASE_URL_V2}categories/c37708ed-3d30-4eac-934f-74bb75256694`,
+    name: 'Express forms',
+    uuid: 'c37708ed-3d30-4eac-934f-74bb75256694',
+    ancestors: [],
+    depth: 1,
+  },
+  {
+    url: `${BASE_URL_V2}categories/fed0a451-341a-4da1-b384-83edb5ef67a4`,
+    name: 'Service realms',
+    uuid: 'fed0a451-341a-4da1-b384-83edb5ef67a4',
+    ancestors: [],
+    depth: 1,
+  },
+  {
+    url: `${BASE_URL_V2}categories/5d1138ae-bb0c-42fe-bcba-f1e7ffc1e79e`,
+    name: 'Housing',
+    uuid: '5d1138ae-bb0c-42fe-bcba-f1e7ffc1e79e',
+    ancestors: [
+      {
+        uuid: 'fed0a451-341a-4da1-b384-83edb5ef67a4',
+        name: 'Service realms',
+      },
+    ],
+    depth: 2,
+  },
+  {
+    url: `${BASE_URL_V2}categories/d65f420d-1d6a-483d-b5e8-7ddf1d6b60b6`,
+    name: 'Moving',
+    uuid: 'd65f420d-1d6a-483d-b5e8-7ddf1d6b60b6',
+    ancestors: [
+      {
+        uuid: 'fed0a451-341a-4da1-b384-83edb5ef67a4',
+        name: 'Service realms',
+      },
+      {
+        uuid: '5d1138ae-bb0c-42fe-bcba-f1e7ffc1e79e',
+        name: 'Housing',
+      },
+    ],
+    depth: 3,
+  },
+  {
+    url: `${BASE_URL_V2}categories/4b626aa4-00ce-4738-aa51-184a95b1f895`,
+    name: 'Family',
+    uuid: '4b626aa4-00ce-4738-aa51-184a95b1f895',
+    ancestors: [
+      {
+        uuid: 'fed0a451-341a-4da1-b384-83edb5ef67a4',
+        name: 'Service realms',
+      },
+    ],
+    depth: 2,
+  },
+];
+
+export const mockCategoriesGet = (spy?: Mock) =>
+  http.get(
+    `${BASE_URL_V2}categories`,
+    info => {
+      // Call the spy with the request info
+      if (spy) spy(info);
+
+      return HttpResponse.json(DEFAULT_CATEGORIES, {
+        headers: {
+          [SESSION_EXPIRES_IN_HEADER]: `3600`, // Set the session expiry to 1 hour
+        },
+        status: 200,
+      });
+    },
+    {once: false}
+  );

--- a/src/api-mocks/form.ts
+++ b/src/api-mocks/form.ts
@@ -3,7 +3,7 @@ import {HttpResponse, http} from 'msw';
 
 import type {Form} from '@/types/form';
 
-import {BASE_URL, getDefaultFactory} from './base';
+import {BASE_URL_V3, getDefaultFactory} from './base';
 
 export const FORM_DEFAULTS: Form = {
   uuid: 'e450890a-4166-410e-8d64-0a54ad30ba01',
@@ -94,7 +94,7 @@ export const buildForm = getDefaultFactory<Form>(FORM_DEFAULTS);
 
 export const mockFormDetailsGet = (formDetail = buildForm(), spy?: Mock) =>
   http.get(
-    `${BASE_URL}form/:uuid`,
+    `${BASE_URL_V3}form/:uuid`,
     info => {
       // Call the spy with the request info
       if (spy) spy(info);
@@ -109,7 +109,7 @@ export const mockFormDetailsGet = (formDetail = buildForm(), spy?: Mock) =>
 
 export const mockFormDetailsGetFailure = (spy?: Mock) =>
   http.get(
-    `${BASE_URL}form/:uuid`,
+    `${BASE_URL_V3}form/:uuid`,
     info => {
       // Call the spy with the request info
       if (spy) spy(info);
@@ -124,7 +124,7 @@ export const mockFormDetailsGetFailure = (spy?: Mock) =>
 
 export const mockFormDetailsPut = (formDetail = buildForm(), spy?: Mock) =>
   http.put(
-    `${BASE_URL}form/:uuid`,
+    `${BASE_URL_V3}form/:uuid`,
     info => {
       // Call the spy with the request info
       if (spy) spy(info);
@@ -139,7 +139,7 @@ export const mockFormDetailsPut = (formDetail = buildForm(), spy?: Mock) =>
 
 export const mockFormDetailsPutFailure = (spy?: Mock) =>
   http.put(
-    `${BASE_URL}form/:uuid`,
+    `${BASE_URL_V3}form/:uuid`,
     info => {
       // Call the spy with the request info
       if (spy) spy(info);

--- a/src/api-mocks/index.ts
+++ b/src/api-mocks/index.ts
@@ -1,7 +1,7 @@
-import {BASE_URL} from './base';
+import {BASE_URL_V2, BASE_URL_V3} from './base';
 import mswWorker from './msw-worker';
 
 export * from './accounts';
 export * from './form';
 
-export {BASE_URL, mswWorker};
+export {BASE_URL_V2, BASE_URL_V3, mswWorker};

--- a/src/api-mocks/index.ts
+++ b/src/api-mocks/index.ts
@@ -2,6 +2,7 @@ import {BASE_URL_V2, BASE_URL_V3} from './base';
 import mswWorker from './msw-worker';
 
 export * from './accounts';
+export * from './category';
 export * from './form';
 
 export {BASE_URL_V2, BASE_URL_V3, mswWorker};

--- a/src/components/form/FormField.scss
+++ b/src/components/form/FormField.scss
@@ -3,4 +3,11 @@
   flex-direction: column;
   align-items: baseline;
   gap: var(--sizes-spacing-xs-v, 8px);
+  margin-block-end: var(--sizes-spacing-s-v, 16px);
+
+  .mykn-select,
+  .mykn-input,
+  .mykn-stackctx {
+    width: 100%;
+  }
 }

--- a/src/components/form/TextField/TextField.stories.tsx
+++ b/src/components/form/TextField/TextField.stories.tsx
@@ -30,6 +30,31 @@ export const Required: Story = {
   args: {
     isRequired: true,
   },
+  play: ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // The field has 'Required' as part of its label content, and the input has
+    // the attribute 'required'
+    expect(canvas.getByText('Required')).toBeVisible();
+    expect(canvas.getByLabelText('Textfield label Required')).toHaveAttribute('required');
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    isReadOnly: true,
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // The input has the accessible 'readonly' attribute
+    const textInput = canvas.getByLabelText('Textfield label');
+    expect(textInput).toHaveAttribute('readonly');
+
+    // Typing in the input shouldn't change its content
+    await userEvent.type(textInput, 'this text should not be added');
+    expect(textInput).toHaveTextContent('');
+  },
 };
 
 export const WithDescription: Story = {

--- a/src/components/form/TextField/TextField.tsx
+++ b/src/components/form/TextField/TextField.tsx
@@ -28,9 +28,19 @@ export interface TextFieldProps {
    * Required fields get additional markup/styling to indicate this validation requirement.
    */
   isRequired?: boolean;
+  /**
+   * Readonly fields get marked as such in an accessible manner.
+   */
+  isReadOnly?: boolean;
 }
 
-const TextField: React.FC<TextFieldProps> = ({name, label, description, isRequired = false}) => {
+const TextField: React.FC<TextFieldProps> = ({
+  name,
+  label,
+  description,
+  isRequired = false,
+  isReadOnly = false,
+}) => {
   const {validateField} = useFormikContext();
   const [{value, ...props}, {error = '', touched}] = useField(name);
   const id = useId();
@@ -59,6 +69,7 @@ const TextField: React.FC<TextFieldProps> = ({name, label, description, isRequir
         required={isRequired}
         value={value ?? ''}
         {...props}
+        readOnly={isReadOnly}
         onBlur={async event => {
           props.onBlur(event);
           await validateField(name);

--- a/src/context/AdminSettingsProvider.tsx
+++ b/src/context/AdminSettingsProvider.tsx
@@ -2,12 +2,12 @@ import {AdminSettingsContext} from './context';
 import type {AdminSettings} from './context';
 
 const AdminSettingsProvider: React.FC<React.PropsWithChildren<AdminSettings>> = ({
-  apiBaseUrl,
+  apiBaseUrls,
   djangoUrls,
   environmentInfo,
   children,
 }) => (
-  <AdminSettingsContext.Provider value={{environmentInfo, djangoUrls, apiBaseUrl}}>
+  <AdminSettingsContext.Provider value={{environmentInfo, djangoUrls, apiBaseUrls}}>
     {children}
   </AdminSettingsContext.Provider>
 );

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -15,9 +15,12 @@ export interface AdminSettings {
     foregroundColor?: string;
   };
   /**
-   * The base URL of the Open Forms API.
+   * The base URLs of the Open Forms API.
    */
-  apiBaseUrl: string;
+  apiBaseUrls: {
+    v2: string;
+    v3: string;
+  };
   /**
    * The configuration of the Open Forms Django URLs.
    */
@@ -29,7 +32,7 @@ export interface AdminSettings {
 
 const AdminSettingsContext = React.createContext<AdminSettings>({
   environmentInfo: {label: '', showBadge: true},
-  apiBaseUrl: '',
+  apiBaseUrls: {v2: '', v3: ''},
   djangoUrls: {generalConfiguration: '', adminLogin: ''},
 });
 

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -27,13 +27,14 @@ export interface AdminSettings {
   djangoUrls: {
     generalConfiguration: string;
     adminLogin: string;
+    publicRoot: string;
   };
 }
 
 const AdminSettingsContext = React.createContext<AdminSettings>({
   environmentInfo: {label: '', showBadge: true},
   apiBaseUrls: {v2: '', v3: ''},
-  djangoUrls: {generalConfiguration: '', adminLogin: ''},
+  djangoUrls: {generalConfiguration: '', adminLogin: '', publicRoot: ''},
 });
 
 AdminSettingsContext.displayName = 'AdminSettingsContext';

--- a/src/guard/AuthenticationRequired.spec.tsx
+++ b/src/guard/AuthenticationRequired.spec.tsx
@@ -5,7 +5,8 @@ import {expect, test, vi} from 'vitest';
 import {render} from 'vitest-browser-react';
 
 import {
-  BASE_URL,
+  BASE_URL_V2,
+  BASE_URL_V3,
   mockAccountsMeAnonymousGet,
   mockAccountsMeAuthenticatedGet,
   mswWorker,
@@ -22,7 +23,7 @@ vi.spyOn(redirect, 'toLogin').mockImplementation(vi.fn());
 
 const Wrapper: React.FC<React.PropsWithChildren> = ({children}) => (
   <AdminSettingsProvider
-    apiBaseUrl={BASE_URL}
+    apiBaseUrls={{v2: BASE_URL_V2, v3: BASE_URL_V3}}
     djangoUrls={{
       generalConfiguration: 'http://localhost:8000/admin/config/globalconfiguration/',
       adminLogin: 'http://localhost:8000/admin/classic-login/',

--- a/src/guard/AuthenticationRequired.spec.tsx
+++ b/src/guard/AuthenticationRequired.spec.tsx
@@ -222,7 +222,11 @@ test('User is not authenticated in application and not on server', async () => {
   await waitFor(() => {
     // The `toLogin` function should be called with the expected redirect path.
     expect(redirect.toLogin).toHaveBeenCalledWith(
-      {adminLogin: expect.anything(), generalConfiguration: expect.anything()},
+      {
+        adminLogin: expect.anything(),
+        generalConfiguration: expect.anything(),
+        publicRoot: expect.anything(),
+      },
       '/required-auth'
     );
 

--- a/src/guard/AuthenticationRequired.spec.tsx
+++ b/src/guard/AuthenticationRequired.spec.tsx
@@ -27,6 +27,7 @@ const Wrapper: React.FC<React.PropsWithChildren> = ({children}) => (
     djangoUrls={{
       generalConfiguration: 'http://localhost:8000/admin/config/globalconfiguration/',
       adminLogin: 'http://localhost:8000/admin/classic-login/',
+      publicRoot: 'http://localhost:8000/',
     }}
     environmentInfo={{label: 'of-dev', showBadge: true}}
   >

--- a/src/guard/AuthenticationRequired.tsx
+++ b/src/guard/AuthenticationRequired.tsx
@@ -9,7 +9,7 @@ import SessionStatus from './session/SessionStatus';
 import {sessionExpiresAt} from './session/session-expiry';
 
 const AuthenticationRequired: React.FC<React.PropsWithChildren> = ({children}) => {
-  const {apiBaseUrl, djangoUrls} = useAdminSettings();
+  const {apiBaseUrls, djangoUrls} = useAdminSettings();
   const location = useLocation();
   const [sessionExpiry] = sessionExpiresAt.useState();
   const {date, authFailure} = sessionExpiry;
@@ -18,14 +18,14 @@ const AuthenticationRequired: React.FC<React.PropsWithChildren> = ({children}) =
     // If there is no session expiry date and no authenticated status,
     // we check with the api if the user is authenticated.
     if (date === null && authFailure === null) {
-      apiCall(`${apiBaseUrl}v3/accounts/me`).then(response => {
+      apiCall(`${apiBaseUrls.v3}accounts/me`).then(response => {
         // If the user is not authenticated, redirect to the login page.
         if (response.status === 401) {
           redirect.toLogin(djangoUrls, location.pathname);
         }
       });
     }
-  }, [apiBaseUrl, authFailure, date, djangoUrls, location.pathname]);
+  }, [apiBaseUrls, authFailure, date, djangoUrls, location.pathname]);
 
   return <SessionStatus>{children}</SessionStatus>;
 };

--- a/src/guard/AuthenticationRequired.tsx
+++ b/src/guard/AuthenticationRequired.tsx
@@ -18,7 +18,7 @@ const AuthenticationRequired: React.FC<React.PropsWithChildren> = ({children}) =
     // If there is no session expiry date and no authenticated status,
     // we check with the api if the user is authenticated.
     if (date === null && authFailure === null) {
-      apiCall(`${apiBaseUrl}accounts/me`).then(response => {
+      apiCall(`${apiBaseUrl}v3/accounts/me`).then(response => {
         // If the user is not authenticated, redirect to the login page.
         if (response.status === 401) {
           redirect.toLogin(djangoUrls, location.pathname);

--- a/src/pages/form-detail/index.ts
+++ b/src/pages/form-detail/index.ts
@@ -1,0 +1,1 @@
+export * from './settings';

--- a/src/pages/form-detail/settings/Information/Information.stories.tsx
+++ b/src/pages/form-detail/settings/Information/Information.stories.tsx
@@ -1,0 +1,113 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {expect, fireEvent, fn, userEvent, waitFor, within} from 'storybook/test';
+
+import {buildForm, mockCategoriesGet, mockFormDetailsGet} from '@/api-mocks';
+import {withFormLayout} from '@/sb-decorators';
+
+import informationPage from './Information';
+
+export default {
+  title: 'Pages / Form detail / Settings / Information',
+  component: informationPage,
+  decorators: [withFormLayout],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof informationPage>;
+
+type Story = StoryObj<typeof informationPage>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [mockFormDetailsGet(), mockCategoriesGet()],
+    },
+  },
+};
+
+export const ManuallyEnterFields: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        mockFormDetailsGet(
+          buildForm({
+            name: '',
+            internalName: '',
+            slug: '',
+          })
+        ),
+        mockCategoriesGet(),
+      ],
+    },
+    formDetailPages: {
+      onMutate: fn(),
+    },
+  },
+  play: async ({canvasElement, step, parameters}) => {
+    const canvas = within(canvasElement);
+
+    const category = await canvas.findByRole('combobox');
+    const nativeSelectForCategory = category.querySelector<HTMLSelectElement>('select[hidden]')!;
+
+    const internalNameField = canvas.getByLabelText('Internal name', {exact: false});
+    const uuidField = canvas.getByLabelText('Unique ID');
+    const slugField = canvas.getByLabelText('Slug', {exact: false});
+
+    await step('Initial values', () => {
+      expect(nativeSelectForCategory.value).toBe('');
+      expect(internalNameField).toHaveValue('');
+      expect(uuidField).toHaveValue('e450890a-4166-410e-8d64-0a54ad30ba01');
+      expect(slugField).toHaveValue('');
+    });
+
+    await step('Entering values', async () => {
+      // Select category
+      await userEvent.click(category, {delay: 10});
+      await userEvent.click(await within(category).findByText('Service realms > Housing'), {
+        delay: 10,
+      });
+
+      // Set the internal name
+      await userEvent.type(internalNameField, 'my form');
+      await userEvent.tab();
+
+      // Try to update the uuid
+      await userEvent.type(uuidField, 'my custom uuid');
+      await userEvent.tab();
+
+      // Set the slug
+      await userEvent.type(slugField, 'my-form');
+      await userEvent.tab();
+    });
+
+    await step('Validating values', async () => {
+      // The category select has the value of the selected category uuid
+      expect(nativeSelectForCategory.value).toBe('5d1138ae-bb0c-42fe-bcba-f1e7ffc1e79e');
+      expect(internalNameField).toHaveValue('my form');
+      // uuid should not have been update
+      expect(uuidField).toHaveValue('e450890a-4166-410e-8d64-0a54ad30ba01');
+      // slug should be a kebab-case variant on the internal name
+      expect(slugField).toHaveValue('my-form');
+    });
+
+    await step('Sumbit form and validate submitted values', async () => {
+      // Using fireEvent.click instead of userEvent.click because userEvent.click doesn't
+      // actually fire a click event, which we need to trigger the form submission.
+      await fireEvent.click(canvas.getByRole('button', {name: 'Save'}));
+
+      await waitFor(() => {
+        expect(parameters.formDetailPages.onMutate).toBeCalled();
+
+        // Expect all config fields to be correctly represented in the submission data.
+        const expectedFormDetails = buildForm({
+          name: '',
+          internalName: 'my form',
+          slug: 'my-form',
+          uuid: 'e450890a-4166-410e-8d64-0a54ad30ba01',
+          category: '5d1138ae-bb0c-42fe-bcba-f1e7ffc1e79e',
+        });
+        expect(parameters.formDetailPages.onMutate).toBeCalledWith(expectedFormDetails);
+      });
+    });
+  },
+};

--- a/src/pages/form-detail/settings/Information/Information.stories.tsx
+++ b/src/pages/form-detail/settings/Information/Information.stories.tsx
@@ -34,6 +34,7 @@ export const ManuallyEnterFields: Story = {
             name: '',
             internalName: '',
             slug: '',
+            suspensionAllowed: false,
           })
         ),
         mockCategoriesGet(),
@@ -52,12 +53,16 @@ export const ManuallyEnterFields: Story = {
     const internalNameField = canvas.getByLabelText('Internal name', {exact: false});
     const uuidField = canvas.getByLabelText('Unique ID');
     const slugField = canvas.getByLabelText('Slug', {exact: false});
+    const fullUrlField = canvas.getByLabelText('Form URL');
+    const suspensionAllowedField = canvas.getByLabelText('Suspension allowed');
 
     await step('Initial values', () => {
       expect(nativeSelectForCategory.value).toBe('');
       expect(internalNameField).toHaveValue('');
       expect(uuidField).toHaveValue('e450890a-4166-410e-8d64-0a54ad30ba01');
       expect(slugField).toHaveValue('');
+      expect(fullUrlField).toHaveValue('');
+      expect(suspensionAllowedField).not.toBeChecked();
     });
 
     await step('Entering values', async () => {
@@ -75,6 +80,9 @@ export const ManuallyEnterFields: Story = {
       await userEvent.type(uuidField, 'my custom uuid');
       await userEvent.tab();
 
+      // Toggle suspension allowed
+      await userEvent.click(suspensionAllowedField);
+
       // Set the slug
       await userEvent.type(slugField, 'my-form');
       await userEvent.tab();
@@ -86,8 +94,10 @@ export const ManuallyEnterFields: Story = {
       expect(internalNameField).toHaveValue('my form');
       // uuid should not have been update
       expect(uuidField).toHaveValue('e450890a-4166-410e-8d64-0a54ad30ba01');
-      // slug should be a kebab-case variant on the internal name
       expect(slugField).toHaveValue('my-form');
+      expect(fullUrlField).toHaveValue('http://localhost:8000/my-form');
+      // suspension allowed should now be checked
+      expect(suspensionAllowedField).toBeChecked();
     });
 
     await step('Sumbit form and validate submitted values', async () => {
@@ -105,6 +115,7 @@ export const ManuallyEnterFields: Story = {
           slug: 'my-form',
           uuid: 'e450890a-4166-410e-8d64-0a54ad30ba01',
           category: '5d1138ae-bb0c-42fe-bcba-f1e7ffc1e79e',
+          suspensionAllowed: true,
         });
         expect(parameters.formDetailPages.onMutate).toBeCalledWith(expectedFormDetails);
       });

--- a/src/pages/form-detail/settings/Information/Information.tsx
+++ b/src/pages/form-detail/settings/Information/Information.tsx
@@ -2,11 +2,14 @@ import {Column, Grid, H2, P} from '@maykin-ui/admin-ui';
 import {useQuery} from '@tanstack/react-query';
 import {FormattedMessage} from 'react-intl';
 
+import {Checkbox} from '@/components/form/Checkbox';
 import {Select} from '@/components/form/Select';
 import {TextField} from '@/components/form/TextField';
 import {useAdminSettings} from '@/hooks/useAdminSettings';
 import type {Category} from '@/types/category';
 import {apiCall} from '@/utils/fetch';
+
+import UrlField from './UrlField';
 
 const InformationPage: React.FC = () => {
   const {apiBaseUrls} = useAdminSettings();
@@ -68,6 +71,15 @@ const InformationPage: React.FC = () => {
             />
           }
         />
+        <Checkbox
+          name="suspensionAllowed"
+          label={
+            <FormattedMessage
+              description="Form detail field 'suspensionAllowed' label"
+              defaultMessage="Suspension allowed"
+            />
+          }
+        />
         <P>
           <FormattedMessage
             description="form detail information settings page 'also for citizen' settings"
@@ -79,6 +91,14 @@ const InformationPage: React.FC = () => {
           isRequired
           label={
             <FormattedMessage description="Form detail field 'slug' label" defaultMessage="Slug" />
+          }
+        />
+        <UrlField
+          label={
+            <FormattedMessage
+              description="Form detail field 'url' label"
+              defaultMessage="Form URL"
+            />
           }
         />
       </Column>

--- a/src/pages/form-detail/settings/Information/Information.tsx
+++ b/src/pages/form-detail/settings/Information/Information.tsx
@@ -1,0 +1,89 @@
+import {Column, Grid, H2, P} from '@maykin-ui/admin-ui';
+import {useQuery} from '@tanstack/react-query';
+import {FormattedMessage} from 'react-intl';
+
+import {Select} from '@/components/form/Select';
+import {TextField} from '@/components/form/TextField';
+import {useAdminSettings} from '@/hooks/useAdminSettings';
+import type {Category} from '@/types/category';
+import {apiCall} from '@/utils/fetch';
+
+const InformationPage: React.FC = () => {
+  const {apiBaseUrls} = useAdminSettings();
+  const {data = []} = useQuery<Category[]>({
+    queryKey: ['form-categories'],
+    queryFn: () => apiCall(`${apiBaseUrls.v2}categories`).then(r => r.json()),
+  });
+
+  const categoryOptions = data.map(category => {
+    const ancestorLabels = (category.ancestors || []).map(ancestor => ancestor.name);
+    return {
+      value: category.uuid,
+      label: [...ancestorLabels, category.name].join(' > '),
+    };
+  });
+
+  return (
+    <Grid>
+      <Column span={5} mobileSpan={12}>
+        <H2>
+          <FormattedMessage
+            description="form detail information settings page title"
+            defaultMessage="Information"
+          />
+        </H2>
+        <P>
+          <FormattedMessage
+            description="form detail information settings page 'only for admin' settings"
+            defaultMessage="There settings are only visible for administrators"
+          />
+        </P>
+        <Select
+          name="category"
+          label={
+            <FormattedMessage
+              description="Form detail field 'category' label"
+              defaultMessage="Category"
+            />
+          }
+          options={categoryOptions}
+        />
+        <TextField
+          name="internalName"
+          isRequired
+          label={
+            <FormattedMessage
+              description="Form detail field 'internalName' label"
+              defaultMessage="Internal name"
+            />
+          }
+        />
+        <TextField
+          name="uuid"
+          isReadOnly
+          label={
+            <FormattedMessage
+              description="Form detail field 'uuid' label"
+              defaultMessage="Unique ID"
+            />
+          }
+        />
+        <P>
+          <FormattedMessage
+            description="form detail information settings page 'also for citizen' settings"
+            defaultMessage="These settings are also visible for citizens"
+          />
+        </P>
+        <TextField
+          name="slug"
+          isRequired
+          label={
+            <FormattedMessage description="Form detail field 'slug' label" defaultMessage="Slug" />
+          }
+        />
+      </Column>
+    </Grid>
+  );
+};
+
+export default InformationPage;

--- a/src/pages/form-detail/settings/Information/UrlField.tsx
+++ b/src/pages/form-detail/settings/Information/UrlField.tsx
@@ -1,0 +1,51 @@
+import {Button, Input, Outline} from '@maykin-ui/admin-ui';
+import {useField} from 'formik';
+import {useId} from 'react';
+
+import FieldDescription from '@/components/form/FieldDescription';
+import FormField from '@/components/form/FormField';
+import Label from '@/components/form/Label';
+import {useAdminSettings} from '@/hooks/useAdminSettings';
+
+interface UrlFieldProps {
+  /**
+   * The (accessible) label for the field - anything that can be rendered.
+   *
+   * You must always provide a label to ensure the field is accessible to users of
+   * assistive technologies.
+   */
+  label: React.ReactNode;
+}
+
+const UrlField: React.FC<UrlFieldProps> = ({label}) => {
+  const {djangoUrls} = useAdminSettings();
+  const [{value: formSlug}] = useField('slug');
+  const id = useId();
+
+  const formUrl = formSlug ? `${djangoUrls.publicRoot}${formSlug}` : '';
+
+  return (
+    <FormField>
+      <FieldDescription>
+        <Label id={id}>{label}</Label>
+      </FieldDescription>
+
+      <Input
+        id={id}
+        value={formUrl}
+        readOnly
+        suffix={
+          <Button
+            variant="transparent"
+            type="button"
+            onClick={() => navigator.clipboard.writeText(formUrl)}
+          >
+            <Outline.Square2StackIcon />
+          </Button>
+        }
+      />
+    </FormField>
+  );
+};
+
+export default UrlField;

--- a/src/pages/form-detail/settings/Information/index.ts
+++ b/src/pages/form-detail/settings/Information/index.ts
@@ -1,0 +1,1 @@
+export {default as InformationPage} from './Information';

--- a/src/pages/form-detail/settings/index.ts
+++ b/src/pages/form-detail/settings/index.ts
@@ -1,0 +1,3 @@
+import {InformationPage} from './Information';
+
+export {InformationPage};

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,1 @@
+export * from './form-detail';

--- a/src/queryClient/form.spec.tsx
+++ b/src/queryClient/form.spec.tsx
@@ -6,7 +6,8 @@ import {describe, expect, it} from 'vitest';
 import {render} from 'vitest-browser-react';
 
 import {
-  BASE_URL,
+  BASE_URL_V2,
+  BASE_URL_V3,
   buildForm,
   mockFormDetailsGet,
   mockFormDetailsGetFailure,
@@ -20,7 +21,7 @@ import type {Form} from '@/types/form';
 
 const AppWrapper: React.FC<React.PropsWithChildren> = ({children}) => (
   <AdminSettingsProvider
-    apiBaseUrl={BASE_URL}
+    apiBaseUrls={{v2: BASE_URL_V2, v3: BASE_URL_V3}}
     djangoUrls={{
       generalConfiguration: 'http://localhost:8000/admin/config/globalconfiguration/',
       adminLogin: 'http://localhost:8000/admin/classic-login/',

--- a/src/queryClient/form.spec.tsx
+++ b/src/queryClient/form.spec.tsx
@@ -59,7 +59,11 @@ describe('formLoader', () => {
     mswWorker.use(mockFormDetailsGet(formDetails));
 
     const testClient = new QueryClient();
-    const result = await formLoader(testClient, 'e450890a-4166-410e-8d64-0a54ad30ba01');
+    const result = await formLoader(
+      BASE_URL_V3,
+      testClient,
+      'e450890a-4166-410e-8d64-0a54ad30ba01'
+    );
 
     await expect(result).toEqual(formDetails);
   });
@@ -68,7 +72,7 @@ describe('formLoader', () => {
     mswWorker.use(mockFormDetailsGetFailure());
 
     const testClient = new QueryClient();
-    const result = formLoader(testClient, 'e450890a-4166-410e-8d64-0a54ad30ba01');
+    const result = formLoader(BASE_URL_V3, testClient, 'e450890a-4166-410e-8d64-0a54ad30ba01');
 
     await expect(result).rejects.toMatchObject({
       status: 404,
@@ -84,7 +88,7 @@ describe('formLoader in router', () => {
     const Stub = createRoutesStub([
       {
         path: '/form-details/:formId',
-        loader: ({params}) => formLoader(testClient, params.formId),
+        loader: ({params}) => formLoader(BASE_URL_V3, testClient, params.formId),
         Component: SimplePage,
       },
     ]);

--- a/src/queryClient/form.spec.tsx
+++ b/src/queryClient/form.spec.tsx
@@ -117,13 +117,15 @@ describe('useFormMutation', () => {
     testClient.setQueryData(getFormDetailsQueryKey(formId), formDetails);
 
     const {getByText} = await render(
-      <QueryClientProviderWrapper client={testClient}>
-        <PageWithFormMutation
-          testClient={testClient}
-          formId={formId}
-          updatedFormDetails={updatedFormDetails}
-        />
-      </QueryClientProviderWrapper>
+      <AppWrapper>
+        <QueryClientProviderWrapper client={testClient}>
+          <PageWithFormMutation
+            testClient={testClient}
+            formId={formId}
+            updatedFormDetails={updatedFormDetails}
+          />
+        </QueryClientProviderWrapper>
+      </AppWrapper>
     );
     await getByText('mutate data').click();
 
@@ -145,13 +147,15 @@ describe('useFormMutation', () => {
     testClient.setQueryData(getFormDetailsQueryKey(formId), formDetails);
 
     const {getByText} = await render(
-      <QueryClientProviderWrapper client={testClient}>
-        <PageWithFormMutation
-          testClient={testClient}
-          formId={formId}
-          updatedFormDetails={updatedFormDetails}
-        />
-      </QueryClientProviderWrapper>
+      <AppWrapper>
+        <QueryClientProviderWrapper client={testClient}>
+          <PageWithFormMutation
+            testClient={testClient}
+            formId={formId}
+            updatedFormDetails={updatedFormDetails}
+          />
+        </QueryClientProviderWrapper>
+      </AppWrapper>
     );
 
     await getByText('mutate data').click();

--- a/src/queryClient/form.spec.tsx
+++ b/src/queryClient/form.spec.tsx
@@ -25,6 +25,7 @@ const AppWrapper: React.FC<React.PropsWithChildren> = ({children}) => (
     djangoUrls={{
       generalConfiguration: 'http://localhost:8000/admin/config/globalconfiguration/',
       adminLogin: 'http://localhost:8000/admin/classic-login/',
+      publicRoot: 'http://localhost:8000/',
     }}
     environmentInfo={{label: 'of-dev', showBadge: true}}
   >

--- a/src/queryClient/form.ts
+++ b/src/queryClient/form.ts
@@ -14,7 +14,7 @@ export const formLoader = (
   return queryClient.ensureQueryData({
     queryKey: getFormDetailsQueryKey(formId),
     queryFn: async () => {
-      const response = await apiCall(`${BASE_URL}form/${formId}`);
+      const response = await apiCall(`${BASE_URL}v3/form/${formId}`);
       if (response.ok) return response.json();
 
       if (response.status === 404) {
@@ -29,7 +29,7 @@ export const formLoader = (
 export const useFormMutation = (queryClient: QueryClient, formId: string) => {
   return useMutation<Form, Error, Form, {previous?: Form}>({
     mutationFn: async newFormDetails => {
-      const response = await apiCall(`${BASE_URL}form/${formId}`, {
+      const response = await apiCall(`${BASE_URL}v3/form/${formId}`, {
         method: 'PUT',
         body: JSON.stringify(newFormDetails),
       });

--- a/src/queryClient/form.ts
+++ b/src/queryClient/form.ts
@@ -1,20 +1,21 @@
 import type {QueryClient} from '@tanstack/react-query';
 import {useMutation} from '@tanstack/react-query';
 
-import {BASE_URL} from '@/api-mocks';
+import {useAdminSettings} from '@/hooks/useAdminSettings';
 import type {Form} from '@/types/form';
 import {apiCall} from '@/utils/fetch';
 
 export const getFormDetailsQueryKey = (formId?: string) => ['formDetails', formId];
 
 export const formLoader = (
+  apiBaseUrl: string,
   queryClient: QueryClient,
   formId?: string
 ): Promise<Form | undefined> => {
   return queryClient.ensureQueryData({
     queryKey: getFormDetailsQueryKey(formId),
     queryFn: async () => {
-      const response = await apiCall(`${BASE_URL}v3/form/${formId}`);
+      const response = await apiCall(`${apiBaseUrl}form/${formId}`);
       if (response.ok) return response.json();
 
       if (response.status === 404) {
@@ -27,9 +28,10 @@ export const formLoader = (
 };
 
 export const useFormMutation = (queryClient: QueryClient, formId: string) => {
+  const {apiBaseUrls} = useAdminSettings();
   return useMutation<Form, Error, Form, {previous?: Form}>({
     mutationFn: async newFormDetails => {
-      const response = await apiCall(`${BASE_URL}v3/form/${formId}`, {
+      const response = await apiCall(`${apiBaseUrls.v3}form/${formId}`, {
         method: 'PUT',
         body: JSON.stringify(newFormDetails),
       });

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -1,4 +1,5 @@
 import FormLayout from '@/components/layout/FormLayout';
+import type {AdminSettings} from '@/context/context';
 import RouterErrorBoundary from '@/errors/RouterErrorBoundary';
 import {formLoader, queryClient} from '@/queryClient';
 import type {Form} from '@/types/form';
@@ -6,7 +7,7 @@ import type {Form} from '@/types/form';
 import formRoutes from './form';
 import type {RouteHandle, RouteObject} from './types';
 
-const routes: RouteObject[] = [
+const routes = (apiBaseUrls: AdminSettings['apiBaseUrls']): RouteObject[] => [
   // All other routes, point back to old admin
   {
     path: '/',
@@ -41,7 +42,7 @@ const routes: RouteObject[] = [
         children: [
           {
             path: ':formId',
-            loader: ({params}) => formLoader(queryClient, params.formId),
+            loader: ({params}) => formLoader(apiBaseUrls.v3, queryClient, params.formId),
             handle: {
               breadcrumbLabel: (_, loaderData) => loaderData?.name ?? 'unknown form',
             } as RouteHandle<Form | undefined>,

--- a/src/routes/form.tsx
+++ b/src/routes/form.tsx
@@ -1,3 +1,5 @@
+import {InformationPage} from '@/pages';
+
 import type {RouteObject} from './types';
 
 const routes: RouteObject[] = [
@@ -58,6 +60,7 @@ const routes: RouteObject[] = [
     children: [
       {
         path: 'general',
+        Component: InformationPage,
       },
       {
         path: 'authentication',

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,0 +1,12 @@
+export type CategoryAncestor = {
+  uuid: string;
+  name: string;
+};
+
+export type Category = {
+  url: string;
+  name: string;
+  uuid: string;
+  ancestors: CategoryAncestor[];
+  depth: number;
+};


### PR DESCRIPTION
Partly closes #12

PR adds:
* the information page component
* updates to the API url's
* readonly feature for the textfield
* small formField styling update
* category type and api mocking

The public url field still needs to be added, this requires https://github.com/maykinmedia/admin-ui/pull/327. Lets do that in a separate PR